### PR TITLE
support configuring INCLUDE_SOURCE_IN_LOCATION feature

### DIFF
--- a/pekko-http-jackson/src/main/resources/reference.conf
+++ b/pekko-http-jackson/src/main/resources/reference.conf
@@ -10,6 +10,12 @@ pekko-http-json {
       max-name-length = 50000
       # max-document-length of -1 means unlimited
       max-document-length = -1
+
+      # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamReadFeature.html
+      # these defaults are the same as the defaults in `StreamReadFeature`
+      feature {
+        include-source-in-location = false
+      }
     }
     write {
       # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamWriteConstraints.html

--- a/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
+++ b/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.{
   JsonFactory,
   JsonFactoryBuilder,
   StreamReadConstraints,
+  StreamReadFeature,
   StreamWriteConstraints
 }
 import org.apache.pekko.http.javadsl.common.JsonEntityStreamingSupport
@@ -80,6 +81,7 @@ object JacksonSupport extends JacksonSupport {
       .asInstanceOf[JsonFactoryBuilder]
       .streamReadConstraints(streamReadConstraints)
       .streamWriteConstraints(streamWriteConstraints)
+      .configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, jacksonConfig.getBoolean("read.feature.include-source-in-location"))
     jsonFactoryBuilder.build()
   }
 }


### PR DESCRIPTION
Jackson 2.16 changed the default of INCLUDE_SOURCE_IN_LOCATION from true to false causing the location no longer to be included in the error message by default.

This change makes it configurable while keeping the default the same as in jackson.

This contribution is my original work and is licensed to the project under the project's open source license.