### PR TITLE
use ByteString.toArrayUnsafe to avoid copying the array

### DIFF
--- a/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
+++ b/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
@@ -111,7 +111,7 @@ trait AvroSupport {
         val schema = AvroSchema[A]
 
         Try {
-          val bytes = bs.toArrayUnsafe
+          val bytes = bs.toArrayUnsafe()
           if (bytes.length == 0) throw Unmarshaller.NoContentException
           AvroInputStream.json[A].from(bytes).build(schema).iterator.next()
         }

--- a/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
+++ b/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
@@ -111,7 +111,7 @@ trait AvroSupport {
         val schema = AvroSchema[A]
 
         Try {
-          val bytes = bs.toArray
+          val bytes = bs.toArrayUnsafe
           if (bytes.length == 0) throw Unmarshaller.NoContentException
           AvroInputStream.json[A].from(bytes).build(schema).iterator.next()
         }

--- a/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
+++ b/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
@@ -205,7 +205,7 @@ trait JacksonSupport {
       objectMapper: ObjectMapper with ClassTagExtensions = defaultObjectMapper
   ): Unmarshaller[ByteString, A] =
     Unmarshaller { _ => bs =>
-      Future.fromTry(Try(objectMapper.readValue[A](bs.toArrayUnsafe)))
+      Future.fromTry(Try(objectMapper.readValue[A](bs.toArrayUnsafe())))
     }
 
   /**

--- a/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
+++ b/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
@@ -205,7 +205,7 @@ trait JacksonSupport {
       objectMapper: ObjectMapper with ClassTagExtensions = defaultObjectMapper
   ): Unmarshaller[ByteString, A] =
     Unmarshaller { _ => bs =>
-      Future.fromTry(Try(objectMapper.readValue[A](bs.toArray)))
+      Future.fromTry(Try(objectMapper.readValue[A](bs.toArrayUnsafe)))
     }
 
   /**

--- a/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
+++ b/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
@@ -136,7 +136,7 @@ trait JsoniterScalaSupport {
       codec: JsonValueCodec[A],
       config: ReaderConfig = defaultReaderConfig
   ): Unmarshaller[ByteString, A] =
-    Unmarshaller(_ => bs => Future.fromTry(Try(readFromArray(bs.toArray, config))))
+    Unmarshaller(_ => bs => Future.fromTry(Try(readFromArray(bs.toArrayUnsafe, config))))
 
   /**
     * HTTP entity => `Source[A, _]`

--- a/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
+++ b/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
@@ -136,7 +136,7 @@ trait JsoniterScalaSupport {
       codec: JsonValueCodec[A],
       config: ReaderConfig = defaultReaderConfig
   ): Unmarshaller[ByteString, A] =
-    Unmarshaller(_ => bs => Future.fromTry(Try(readFromArray(bs.toArrayUnsafe, config))))
+    Unmarshaller(_ => bs => Future.fromTry(Try(readFromArray(bs.toArrayUnsafe(), config))))
 
   /**
     * HTTP entity => `Source[A, _]`

--- a/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
+++ b/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
@@ -91,7 +91,7 @@ trait NinnySupport {
     */
   implicit def fromByteStringUnmarshaller[A: FromJson]: Unmarshaller[ByteString, A] =
     Unmarshaller(_ =>
-      bs => Future.fromTry(Json.parse(new String(bs.toArrayUnsafe, StandardCharsets.UTF_8)).to[A])
+      bs => Future.fromTry(Json.parse(new String(bs.toArrayUnsafe(), StandardCharsets.UTF_8)).to[A])
     )
 
   /**

--- a/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
+++ b/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
@@ -91,7 +91,7 @@ trait NinnySupport {
     */
   implicit def fromByteStringUnmarshaller[A: FromJson]: Unmarshaller[ByteString, A] =
     Unmarshaller(_ =>
-      bs => Future.fromTry(Json.parse(new String(bs.toArray, StandardCharsets.UTF_8)).to[A])
+      bs => Future.fromTry(Json.parse(new String(bs.toArrayUnsafe, StandardCharsets.UTF_8)).to[A])
     )
 
   /**

--- a/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
+++ b/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
@@ -140,7 +140,7 @@ trait PlayJsonSupport {
     *   unmarshaller for any `A` value
     */
   implicit def fromByteStringUnmarshaller[A: Reads]: Unmarshaller[ByteString, A] =
-    Unmarshaller(_ => bs => Future.fromTry(Try(Json.parse(bs.toArray).as[A])))
+    Unmarshaller(_ => bs => Future.fromTry(Try(Json.parse(bs.toArrayUnsafe).as[A])))
 
   /**
     * HTTP entity => `Source[A, _]`

--- a/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
+++ b/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
@@ -140,7 +140,7 @@ trait PlayJsonSupport {
     *   unmarshaller for any `A` value
     */
   implicit def fromByteStringUnmarshaller[A: Reads]: Unmarshaller[ByteString, A] =
-    Unmarshaller(_ => bs => Future.fromTry(Try(Json.parse(bs.toArrayUnsafe).as[A])))
+    Unmarshaller(_ => bs => Future.fromTry(Try(Json.parse(bs.toArrayUnsafe()).as[A])))
 
   /**
     * HTTP entity => `Source[A, _]`

--- a/pekko-http-upickle/src/main/scala/com/github/pjfanning/pekkohttpupickle/UpickleCustomizationSupport.scala
+++ b/pekko-http-upickle/src/main/scala/com/github/pjfanning/pekkohttpupickle/UpickleCustomizationSupport.scala
@@ -110,7 +110,7 @@ trait UpickleCustomizationSupport {
     *   unmarshaller for any `A` value
     */
   implicit def fromByteStringUnmarshaller[A: api.Reader]: Unmarshaller[ByteString, A] =
-    Unmarshaller(_ => bs => Future.fromTry(Try(api.read(bs.toArray))))
+    Unmarshaller(_ => bs => Future.fromTry(Try(api.read(bs.toArrayUnsafe))))
 
   /**
     * HTTP entity => `A`

--- a/pekko-http-upickle/src/main/scala/com/github/pjfanning/pekkohttpupickle/UpickleCustomizationSupport.scala
+++ b/pekko-http-upickle/src/main/scala/com/github/pjfanning/pekkohttpupickle/UpickleCustomizationSupport.scala
@@ -110,7 +110,7 @@ trait UpickleCustomizationSupport {
     *   unmarshaller for any `A` value
     */
   implicit def fromByteStringUnmarshaller[A: api.Reader]: Unmarshaller[ByteString, A] =
-    Unmarshaller(_ => bs => Future.fromTry(Try(api.read(bs.toArrayUnsafe))))
+    Unmarshaller(_ => bs => Future.fromTry(Try(api.read(bs.toArrayUnsafe()))))
 
   /**
     * HTTP entity => `A`


### PR DESCRIPTION
ByteString does not mutate its underling array(s). As long as the JSON libs don't mess with the byte array, then 'unsafe' is ok.