### PR TITLE
use ByteString.utf8String

### DIFF
--- a/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
+++ b/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
@@ -90,9 +90,7 @@ trait NinnySupport {
     *   unmarshaller for any `A` value
     */
   implicit def fromByteStringUnmarshaller[A: FromJson]: Unmarshaller[ByteString, A] =
-    Unmarshaller(_ =>
-      bs => Future.fromTry(Json.parse(new String(bs.toArrayUnsafe(), StandardCharsets.UTF_8)).to[A])
-    )
+    Unmarshaller(_ => bs => Future.fromTry(Json.parse(bs.utf8String).to[A]))
 
   /**
     * HTTP entity => `Source[A, _]`


### PR DESCRIPTION
should be faster than using ByteString.toArray and creating a String from that