### PR TITLE
Add a module for jsoniter-scala-circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val `pekko-http-json` =
       `pekko-http-jackson3`,
       `pekko-http-json4s`,
       `pekko-http-jsoniter-scala`,
+      `pekko-http-jsoniter-scala-circe`,
       `pekko-http-ninny`,
       `pekko-http-play-json`,
       `pekko-http-upickle`,
@@ -165,6 +166,22 @@ lazy val `pekko-http-jsoniter-scala` =
         library.pekkoStream         % Provided,
         library.jsoniterScalaMacros % Test,
         library.scalaTest           % Test,
+      )
+    )
+
+lazy val `pekko-http-jsoniter-scala-circe` =
+  project
+    .dependsOn(`pekko-http-circe-base`)
+    .settings(commonSettings, withScala3)
+    .settings(
+      libraryDependencies ++= Seq(
+        library.pekkoHttp,
+        library.circe,
+        library.jsoniterScalaCore,
+        library.jsoniterScalaCirce,
+        library.pekkoStream  % Provided,
+        library.circeGeneric % Test,
+        library.scalaTest    % Test,
       )
     )
 
@@ -277,6 +294,7 @@ lazy val library =
     val json4sCore           = "org.json4s"                            %% "json4s-core"           % Version.json4s
     val json4sJackson        = "org.json4s"                            %% "json4s-jackson"        % Version.json4s
     val json4sNative         = "org.json4s"                            %% "json4s-native"         % Version.json4s
+    val jsoniterScalaCirce   = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe"  % Version.jsoniterScala
     val jsoniterScalaCore    = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % Version.jsoniterScala
     val jsoniterScalaMacros  = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % Version.jsoniterScala
     val ninny                = "tk.nrktkt"                             %% "ninny"                 % Version.ninny

--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ lazy val `pekko-http-json` =
       `pekko-http-argonaut`,
       `pekko-http-avro4s`,
       `pekko-http-circe`,
+      `pekko-http-circe-base`,
       `pekko-http-jackson`,
       `pekko-http-jackson3`,
       `pekko-http-json4s`,
@@ -90,6 +91,7 @@ lazy val `pekko-http-argonaut` =
 
 lazy val `pekko-http-circe` =
   project
+    .dependsOn(`pekko-http-circe-base`)
     .settings(commonSettings, withScala3)
     .settings(
       libraryDependencies ++= Seq(
@@ -101,6 +103,18 @@ lazy val `pekko-http-circe` =
         library.scalaTest    % Test,
       )
     )
+
+lazy val `pekko-http-circe-base` =
+  project
+    .settings(commonSettings, withScala3)
+    .settings(
+      libraryDependencies ++= Seq(
+        library.pekkoHttp,
+        library.circe,
+        library.pekkoStream % Provided
+      )
+    )
+    .settings(publishArtifact := false)
 
 lazy val `pekko-http-jackson` =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,8 @@ lazy val `pekko-http-circe` =
     .settings(commonSettings, withScala3)
     .dependsOn(`pekko-http-circe-base`)
     .settings(
+      // We don't want to publish pekko-http-circe-base, but want to have its classes available for users of
+      // pekko-http-circe.
       Compile / packageBin / mappings ++= (`pekko-http-circe-base` / Compile / packageBin / mappings).value
     )
     .settings(
@@ -177,6 +179,8 @@ lazy val `pekko-http-jsoniter-scala-circe` =
     .settings(commonSettings, withScala3)
     .dependsOn(`pekko-http-circe-base`)
     .settings(
+      // We don't want to publish pekko-http-circe-base, but want to have its classes available for users of
+      // pekko-http-jsoniter-scala-circe.
       Compile / packageBin / mappings ++= (`pekko-http-circe-base` / Compile / packageBin / mappings).value
     )
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -92,8 +92,11 @@ lazy val `pekko-http-argonaut` =
 
 lazy val `pekko-http-circe` =
   project
-    .dependsOn(`pekko-http-circe-base`)
     .settings(commonSettings, withScala3)
+    .dependsOn(`pekko-http-circe-base`)
+    .settings(
+      Compile / packageBin / mappings ++= (`pekko-http-circe-base` / Compile / packageBin / mappings).value
+    )
     .settings(
       libraryDependencies ++= Seq(
         library.pekkoHttp,
@@ -108,6 +111,7 @@ lazy val `pekko-http-circe` =
 lazy val `pekko-http-circe-base` =
   project
     .settings(commonSettings, withScala3)
+    .settings(publishArtifact := false)
     .settings(
       libraryDependencies ++= Seq(
         library.pekkoHttp,
@@ -115,7 +119,6 @@ lazy val `pekko-http-circe-base` =
         library.pekkoStream % Provided
       )
     )
-    .settings(publishArtifact := false)
 
 lazy val `pekko-http-jackson` =
   project
@@ -171,8 +174,11 @@ lazy val `pekko-http-jsoniter-scala` =
 
 lazy val `pekko-http-jsoniter-scala-circe` =
   project
-    .dependsOn(`pekko-http-circe-base`)
     .settings(commonSettings, withScala3)
+    .dependsOn(`pekko-http-circe-base`)
+    .settings(
+      Compile / packageBin / mappings ++= (`pekko-http-circe-base` / Compile / packageBin / mappings).value
+    )
     .settings(
       libraryDependencies ++= Seq(
         library.pekkoHttp,

--- a/pekko-http-circe-base/src/main/scala/com/github/pjfanning/pekkohttpcircebase/BaseSupport.scala
+++ b/pekko-http-circe-base/src/main/scala/com/github/pjfanning/pekkohttpcircebase/BaseSupport.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpcircebase
+
+import org.apache.pekko.http.scaladsl.common.{ EntityStreamingSupport, JsonEntityStreamingSupport }
+import org.apache.pekko.http.scaladsl.marshalling.ToEntityMarshaller
+import org.apache.pekko.http.scaladsl.marshalling.{ Marshaller, Marshalling }
+import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
+import org.apache.pekko.http.scaladsl.model.{
+  ContentType,
+  ContentTypeRange,
+  HttpEntity,
+  MediaType,
+  MessageEntity
+}
+import org.apache.pekko.http.scaladsl.unmarshalling.{
+  FromEntityUnmarshaller,
+  Unmarshal,
+  Unmarshaller
+}
+import org.apache.pekko.http.scaladsl.util.FastFuture
+import org.apache.pekko.stream.scaladsl.{ Flow, Source }
+import org.apache.pekko.util.ByteString
+import cats.data.{ NonEmptyList, ValidatedNel }
+import cats.syntax.either._
+import cats.syntax.show._
+import io.circe.{ Json, ParsingFailure }
+import io.circe.{ Decoder, DecodingFailure, Encoder, Printer }
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+trait BaseSupport {
+
+  /**
+    * HTTP entity => `Json`
+    *
+    * @return
+    *   unmarshaller for `Json`
+    */
+  implicit def jsonUnmarshaller: FromEntityUnmarshaller[Json]
+
+  /**
+    * HTTP entity => `Either[io.circe.ParsingFailure, Json]`
+    *
+    * @return
+    *   unmarshaller for `Either[io.circe.ParsingFailure, Json]`
+    */
+  implicit def safeJsonUnmarshaller: FromEntityUnmarshaller[Either[ParsingFailure, Json]]
+
+  def byteStringJsonUnmarshaller: Unmarshaller[ByteString, Json]
+
+  type SourceOf[A] = Source[A, _]
+
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  protected val defaultMediaTypes: Seq[MediaType.WithFixedCharset] = List(`application/json`)
+  def mediaTypes: Seq[MediaType.WithFixedCharset]                  = defaultMediaTypes
+
+  protected def sourceByteStringMarshaller(
+      mediaType: MediaType.WithFixedCharset
+  ): Marshaller[SourceOf[ByteString], MessageEntity] =
+    Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
+      try
+        FastFuture.successful {
+          Marshalling.WithFixedContentType(
+            mediaType,
+            () => HttpEntity(contentType = mediaType, data = value)
+          ) :: Nil
+        }
+      catch {
+        case NonFatal(e) => FastFuture.failed(e)
+      }
+    }
+
+  protected val jsonSourceStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(sourceByteStringMarshaller)
+
+  protected def jsonSource[A](entitySource: SourceOf[A])(implicit
+      encoder: Encoder[A],
+      printer: Printer,
+      support: JsonEntityStreamingSupport
+  ): SourceOf[ByteString] =
+    entitySource
+      .map(encoder.apply)
+      .map(printer.printToByteBuffer)
+      .map(ByteString(_))
+      .via(support.framingRenderer)
+
+  /**
+    * `ByteString` => `A`
+    *
+    * @tparam A
+    *   type to decode
+    * @return
+    *   unmarshaller for any `A` value
+    */
+  implicit def fromByteStringUnmarshaller[A: Decoder]: Unmarshaller[ByteString, A]
+
+  /**
+    * `Json` => HTTP entity
+    *
+    * @return
+    *   marshaller for JSON value
+    */
+  implicit final def jsonMarshaller(implicit
+      printer: Printer = Printer.noSpaces
+  ): ToEntityMarshaller[Json] =
+    Marshaller.oneOf(mediaTypes: _*) { mediaType =>
+      Marshaller.withFixedContentType(ContentType(mediaType)) { json =>
+        HttpEntity(
+          mediaType,
+          ByteString(printer.printToByteBuffer(json, mediaType.charset.nioCharset()))
+        )
+      }
+    }
+
+  /**
+    * `A` => HTTP entity
+    *
+    * @tparam A
+    *   type to encode
+    * @return
+    *   marshaller for any `A` value
+    */
+  implicit final def marshaller[A: Encoder](implicit
+      printer: Printer = Printer.noSpaces
+  ): ToEntityMarshaller[A] =
+    jsonMarshaller(printer).compose(Encoder[A].apply)
+
+  /**
+    * HTTP entity => `A`
+    *
+    * @tparam A
+    *   type to decode
+    * @return
+    *   unmarshaller for `A`
+    */
+  implicit def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A]
+
+  /**
+    * HTTP entity => `Source[A, _]`
+    *
+    * @tparam A
+    *   type to decode
+    * @return
+    *   unmarshaller for `Source[A, _]`
+    */
+  implicit def sourceUnmarshaller[A: Decoder](implicit
+      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): FromEntityUnmarshaller[SourceOf[A]] =
+    Unmarshaller
+      .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        def asyncParse(bs: ByteString) =
+          Unmarshal(bs).to[A]
+
+        def ordered =
+          Flow[ByteString].mapAsync(support.parallelism)(asyncParse)
+
+        def unordered =
+          Flow[ByteString].mapAsyncUnordered(support.parallelism)(asyncParse)
+
+        Future.successful {
+          entity.dataBytes
+            .via(support.framingDecoder)
+            .via(if (support.unordered) unordered else ordered)
+        }
+      }
+      .forContentTypes(unmarshallerContentTypes: _*)
+
+  /**
+    * `SourceOf[A]` => HTTP entity
+    *
+    * @tparam A
+    *   type to encode
+    * @return
+    *   marshaller for any `SourceOf[A]` value
+    */
+  implicit def sourceMarshaller[A](implicit
+      writes: Encoder[A],
+      printer: Printer = Printer.noSpaces,
+      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): ToEntityMarshaller[SourceOf[A]] =
+    jsonSourceStringMarshaller.compose(jsonSource[A])
+}
+
+trait FailFastSupport extends BaseSupport {
+  override implicit final def fromByteStringUnmarshaller[A: Decoder]: Unmarshaller[ByteString, A] =
+    byteStringJsonUnmarshaller
+      .map(Decoder[A].decodeJson)
+      .map(_.fold(throw _, identity))
+
+  override implicit final def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A] =
+    jsonUnmarshaller
+      .map(Decoder[A].decodeJson)
+      .map(_.fold(throw _, identity))
+
+  implicit final def safeUnmarshaller[A: Decoder]
+      : FromEntityUnmarshaller[Either[io.circe.Error, A]] =
+    safeJsonUnmarshaller.map(_.flatMap(Decoder[A].decodeJson))
+}
+
+trait ErrorAccumulatingSupport extends BaseSupport {
+  private def decode[A: Decoder](json: Json) =
+    Decoder[A].decodeAccumulating(json.hcursor)
+
+  override implicit final def fromByteStringUnmarshaller[A: Decoder]: Unmarshaller[ByteString, A] =
+    byteStringJsonUnmarshaller
+      .map(decode[A])
+      .map(
+        _.fold(failures => throw ErrorAccumulatingSupport.DecodingFailures(failures), identity)
+      )
+
+  override implicit final def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A] =
+    jsonUnmarshaller
+      .map(decode[A])
+      .map(
+        _.fold(failures => throw ErrorAccumulatingSupport.DecodingFailures(failures), identity)
+      )
+
+  implicit final def safeUnmarshaller[A: Decoder]
+      : FromEntityUnmarshaller[ValidatedNel[io.circe.Error, A]] =
+    safeJsonUnmarshaller.map(_.toValidatedNel andThen decode[A])
+}
+
+object ErrorAccumulatingSupport {
+  final case class DecodingFailures(failures: NonEmptyList[DecodingFailure]) extends Exception {
+    override def getMessage: String = failures.toList.map(_.show).mkString("\n")
+  }
+}

--- a/pekko-http-circe/src/main/scala/com/github/pjfanning/pekkohttpcirce/CirceSupport.scala
+++ b/pekko-http-circe/src/main/scala/com/github/pjfanning/pekkohttpcirce/CirceSupport.scala
@@ -16,34 +16,17 @@
 
 package com.github.pjfanning.pekkohttpcirce
 
-import org.apache.pekko.http.javadsl.common.JsonEntityStreamingSupport
-import org.apache.pekko.http.scaladsl.common.EntityStreamingSupport
-import org.apache.pekko.http.scaladsl.marshalling.{ Marshaller, Marshalling, ToEntityMarshaller }
-import org.apache.pekko.http.scaladsl.model.{
-  ContentType,
-  ContentTypeRange,
-  HttpEntity,
-  MediaType,
-  MessageEntity
-}
-import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
-import org.apache.pekko.http.scaladsl.util.FastFuture
-import org.apache.pekko.stream.scaladsl.{ Flow, Source }
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.util.ByteString
-import cats.data.{ NonEmptyList, ValidatedNel }
-import cats.syntax.either.catsSyntaxEither
-import cats.syntax.show.toShow
-import io.circe.{ Decoder, DecodingFailure, Encoder, Json, Printer, jawn }
+import com.github.pjfanning.pekkohttpcircebase.{
+  BaseSupport,
+  ErrorAccumulatingSupport,
+  FailFastSupport
+}
+import io.circe.{ Json, jawn }
 import io.circe.parser.parse
 
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
-import scala.util.control.NonFatal
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol. The
@@ -67,11 +50,7 @@ trait FailFastCirceSupport extends BaseCirceSupport with FailFastUnmarshaller
   *
   * To use automatic codec derivation, user needs to import `io.circe.generic.auto._`.
   */
-object ErrorAccumulatingCirceSupport extends ErrorAccumulatingCirceSupport {
-  final case class DecodingFailures(failures: NonEmptyList[DecodingFailure]) extends Exception {
-    override def getMessage: String = failures.toList.map(_.show).mkString("\n")
-  }
-}
+object ErrorAccumulatingCirceSupport extends ErrorAccumulatingCirceSupport
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol. The
@@ -84,93 +63,8 @@ trait ErrorAccumulatingCirceSupport extends BaseCirceSupport with ErrorAccumulat
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol.
   */
-trait BaseCirceSupport {
-  type SourceOf[A] = Source[A, _]
-
-  def unmarshallerContentTypes: Seq[ContentTypeRange] =
-    mediaTypes.map(ContentTypeRange.apply)
-
-  private val defaultMediaTypes: Seq[MediaType.WithFixedCharset] = List(`application/json`)
-  def mediaTypes: Seq[MediaType.WithFixedCharset]                = defaultMediaTypes
-
-  private def sourceByteStringMarshaller(
-      mediaType: MediaType.WithFixedCharset
-  ): Marshaller[SourceOf[ByteString], MessageEntity] =
-    Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
-      try
-        FastFuture.successful {
-          Marshalling.WithFixedContentType(
-            mediaType,
-            () => HttpEntity(contentType = mediaType, data = value)
-          ) :: Nil
-        }
-      catch {
-        case NonFatal(e) => FastFuture.failed(e)
-      }
-    }
-
-  private val jsonSourceStringMarshaller =
-    Marshaller.oneOf(mediaTypes: _*)(sourceByteStringMarshaller)
-
-  private def jsonSource[A](entitySource: SourceOf[A])(implicit
-      encoder: Encoder[A],
-      printer: Printer,
-      support: JsonEntityStreamingSupport
-  ): SourceOf[ByteString] =
-    entitySource
-      .map(encoder.apply)
-      .map(printer.printToByteBuffer)
-      .map(ByteString(_))
-      .via(support.framingRenderer)
-
-  /**
-    * `ByteString` => `A`
-    *
-    * @tparam A
-    *   type to decode
-    * @return
-    *   unmarshaller for any `A` value
-    */
-  implicit def fromByteStringUnmarshaller[A: Decoder]: Unmarshaller[ByteString, A]
-
-  /**
-    * `Json` => HTTP entity
-    *
-    * @return
-    *   marshaller for JSON value
-    */
-  implicit final def jsonMarshaller(implicit
-      printer: Printer = Printer.noSpaces
-  ): ToEntityMarshaller[Json] =
-    Marshaller.oneOf(mediaTypes: _*) { mediaType =>
-      Marshaller.withFixedContentType(ContentType(mediaType)) { json =>
-        HttpEntity(
-          mediaType,
-          ByteString(printer.printToByteBuffer(json, mediaType.charset.nioCharset()))
-        )
-      }
-    }
-
-  /**
-    * `A` => HTTP entity
-    *
-    * @tparam A
-    *   type to encode
-    * @return
-    *   marshaller for any `A` value
-    */
-  implicit final def marshaller[A: Encoder](implicit
-      printer: Printer = Printer.noSpaces
-  ): ToEntityMarshaller[A] =
-    jsonMarshaller(printer).compose(Encoder[A].apply)
-
-  /**
-    * HTTP entity => `Json`
-    *
-    * @return
-    *   unmarshaller for `Json`
-    */
-  implicit final val jsonUnmarshaller: FromEntityUnmarshaller[Json] =
+trait BaseCirceSupport extends BaseSupport {
+  override implicit final val jsonUnmarshaller: FromEntityUnmarshaller[Json] =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(unmarshallerContentTypes: _*)
       .map {
@@ -178,29 +72,13 @@ trait BaseCirceSupport {
         case data             => jawn.parseByteBuffer(data.asByteBuffer).fold(throw _, identity)
       }
 
-  /**
-    * HTTP entity => `Either[io.circe.ParsingFailure, Json]`
-    *
-    * @return
-    *   unmarshaller for `Either[io.circe.ParsingFailure, Json]`
-    */
-  implicit final val safeJsonUnmarshaller
+  override implicit final val safeJsonUnmarshaller
       : FromEntityUnmarshaller[Either[io.circe.ParsingFailure, Json]] =
     Unmarshaller.stringUnmarshaller
       .forContentTypes(unmarshallerContentTypes: _*)
       .map(parse)
 
-  /**
-    * HTTP entity => `A`
-    *
-    * @tparam A
-    *   type to decode
-    * @return
-    *   unmarshaller for `A`
-    */
-  implicit def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A]
-
-  def byteStringJsonUnmarshaller: Unmarshaller[ByteString, Json] =
+  override def byteStringJsonUnmarshaller: Unmarshaller[ByteString, Json] =
     Unmarshaller { ec => bs =>
       Future {
         jawn.parseByteBuffer(bs.asByteBuffer) match {
@@ -209,94 +87,14 @@ trait BaseCirceSupport {
         }
       }(ec)
     }
-
-  /**
-    * HTTP entity => `Source[A, _]`
-    *
-    * @tparam A
-    *   type to decode
-    * @return
-    *   unmarshaller for `Source[A, _]`
-    */
-  implicit def sourceUnmarshaller[A: Decoder](implicit
-      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
-  ): FromEntityUnmarshaller[SourceOf[A]] =
-    Unmarshaller
-      .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
-        def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
-
-        def ordered =
-          Flow[ByteString].mapAsync(support.parallelism)(asyncParse)
-
-        def unordered =
-          Flow[ByteString].mapAsyncUnordered(support.parallelism)(asyncParse)
-
-        Future.successful {
-          entity.dataBytes
-            .via(support.framingDecoder)
-            .via(if (support.unordered) unordered else ordered)
-        }
-      }
-      .forContentTypes(unmarshallerContentTypes: _*)
-
-  /**
-    * `SourceOf[A]` => HTTP entity
-    *
-    * @tparam A
-    *   type to encode
-    * @return
-    *   marshaller for any `SourceOf[A]` value
-    */
-  implicit def sourceMarshaller[A](implicit
-      writes: Encoder[A],
-      printer: Printer = Printer.noSpaces,
-      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
-  ): ToEntityMarshaller[SourceOf[A]] =
-    jsonSourceStringMarshaller.compose(jsonSource[A])
 }
 
 /**
   * Mix-in this trait to fail on the first error during unmarshalling.
   */
-trait FailFastUnmarshaller { this: BaseCirceSupport =>
-  override implicit final def fromByteStringUnmarshaller[A: Decoder]: Unmarshaller[ByteString, A] =
-    byteStringJsonUnmarshaller
-      .map(Decoder[A].decodeJson)
-      .map(_.fold(throw _, identity))
-
-  override implicit final def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A] =
-    jsonUnmarshaller
-      .map(Decoder[A].decodeJson)
-      .map(_.fold(throw _, identity))
-
-  implicit final def safeUnmarshaller[A: Decoder]
-      : FromEntityUnmarshaller[Either[io.circe.Error, A]] =
-    safeJsonUnmarshaller.map(_.flatMap(Decoder[A].decodeJson))
-}
+trait FailFastUnmarshaller extends FailFastSupport
 
 /**
   * Mix-in this trait to accumulate all errors during unmarshalling.
   */
-trait ErrorAccumulatingUnmarshaller { this: BaseCirceSupport =>
-  private def decode[A: Decoder](json: Json) =
-    Decoder[A].decodeAccumulating(json.hcursor)
-
-  override implicit final def fromByteStringUnmarshaller[A: Decoder]: Unmarshaller[ByteString, A] =
-    byteStringJsonUnmarshaller
-      .map(decode[A])
-      .map(
-        _.fold(failures => throw ErrorAccumulatingCirceSupport.DecodingFailures(failures), identity)
-      )
-
-  override implicit final def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A] =
-    jsonUnmarshaller
-      .map(decode[A])
-      .map(
-        _.fold(failures => throw ErrorAccumulatingCirceSupport.DecodingFailures(failures), identity)
-      )
-
-  implicit final def safeUnmarshaller[A: Decoder]
-      : FromEntityUnmarshaller[ValidatedNel[io.circe.Error, A]] =
-    safeJsonUnmarshaller.map(_.toValidatedNel andThen decode[A])
-}
+trait ErrorAccumulatingUnmarshaller extends ErrorAccumulatingSupport

--- a/pekko-http-circe/src/test/scala/com/github/pjfanning/pekkohttpcirce/CirceSupportSpec.scala
+++ b/pekko-http-circe/src/test/scala/com/github/pjfanning/pekkohttpcirce/CirceSupportSpec.scala
@@ -22,6 +22,7 @@ import org.apache.pekko.http.scaladsl.model.ContentTypes.{ `application/json`, `
 import org.apache.pekko.http.scaladsl.model._
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import org.apache.pekko.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import com.github.pjfanning.pekkohttpcircebase.ErrorAccumulatingSupport
 import cats.data.{ NonEmptyList, ValidatedNel }
 import cats.implicits.toShow
 import io.circe.CursorOp.DownField
@@ -189,7 +190,7 @@ final class CirceSupportSpec
           DecodingFailure("Got value '1' with wrong type, expecting string", List(DownField("a"))),
           DecodingFailure("Got value '2' with wrong type, expecting string", List(DownField("b")))
         )
-      val errorMessage = ErrorAccumulatingCirceSupport.DecodingFailures(errors).getMessage
+      val errorMessage = ErrorAccumulatingSupport.DecodingFailures(errors).getMessage
       Unmarshal(entity)
         .to[MultiFoo]
         .failed
@@ -203,7 +204,7 @@ final class CirceSupportSpec
           DecodingFailure("Got value '1' with wrong type, expecting string", List(DownField("a"))),
           DecodingFailure("Got value '2' with wrong type, expecting string", List(DownField("b")))
         )
-      val errorMessage = ErrorAccumulatingCirceSupport.DecodingFailures(errors).getMessage
+      val errorMessage = ErrorAccumulatingSupport.DecodingFailures(errors).getMessage
       val result: String = Unmarshal(entity)
         .to[ValidatedNel[io.circe.Error, MultiFoo]]
         .futureValue

--- a/pekko-http-jsoniter-scala-circe/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscalacirce/CirceSupport.scala
+++ b/pekko-http-jsoniter-scala-circe/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscalacirce/CirceSupport.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjsoniterscalacirce
+
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
+import org.apache.pekko.util.ByteString
+import com.github.pjfanning.pekkohttpcircebase.{
+  BaseSupport,
+  ErrorAccumulatingSupport,
+  FailFastSupport
+}
+import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec._
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import io.circe.{ Json, ParsingFailure }
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+/**
+  * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol. The
+  * unmarshaller fails fast, throwing the first `Error` encountered.
+  *
+  * To use automatic codec derivation, user needs to import `io.circe.generic.auto._`.
+  */
+object FailFastCirceSupport extends FailFastCirceSupport
+
+/**
+  * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol. The
+  * unmarshaller fails fast, throwing the first `Error` encountered.
+  *
+  * To use automatic codec derivation import `io.circe.generic.auto._`.
+  */
+trait FailFastCirceSupport extends BaseCirceSupport with FailFastUnmarshaller
+
+/**
+  * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol. The
+  * unmarshaller accumulates all errors in the exception `Errors`.
+  *
+  * To use automatic codec derivation, user needs to import `io.circe.generic.auto._`.
+  */
+object ErrorAccumulatingCirceSupport extends ErrorAccumulatingCirceSupport
+
+/**
+  * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol. The
+  * unmarshaller accumulates all errors in the exception `Errors`.
+  *
+  * To use automatic codec derivation import `io.circe.generic.auto._`.
+  */
+trait ErrorAccumulatingCirceSupport extends BaseCirceSupport with ErrorAccumulatingUnmarshaller
+
+/**
+  * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol.
+  */
+trait BaseCirceSupport extends BaseSupport {
+  override implicit final val jsonUnmarshaller: FromEntityUnmarshaller[Json] =
+    Unmarshaller.byteStringUnmarshaller
+      .forContentTypes(unmarshallerContentTypes: _*)
+      .map {
+        case ByteString.empty => throw Unmarshaller.NoContentException
+        case data             => readFromByteBuffer[Json](data.asByteBuffer)
+      }
+
+  override implicit final val safeJsonUnmarshaller
+      : FromEntityUnmarshaller[Either[ParsingFailure, Json]] =
+    Unmarshaller.stringUnmarshaller
+      .forContentTypes(unmarshallerContentTypes: _*)
+      .map(s =>
+        try
+          Right(readFromString[Json](s))
+        catch {
+          case NonFatal(e) => Left(new ParsingFailure(e.getMessage(), e))
+        }
+      )
+
+  override def byteStringJsonUnmarshaller: Unmarshaller[ByteString, Json] =
+    Unmarshaller { ec => bs =>
+      Future(readFromByteBuffer[Json](bs.asByteBuffer))(ec)
+    }
+}
+
+/**
+  * Mix-in this trait to fail on the first error during unmarshalling.
+  */
+trait FailFastUnmarshaller extends FailFastSupport
+
+/**
+  * Mix-in this trait to accumulate all errors during unmarshalling.
+  */
+trait ErrorAccumulatingUnmarshaller extends ErrorAccumulatingSupport

--- a/pekko-http-jsoniter-scala-circe/src/test/scala/com/github/pjfanning/pekkohttpjsoniterscalacirce/CirceSupportSpec.scala
+++ b/pekko-http-jsoniter-scala-circe/src/test/scala/com/github/pjfanning/pekkohttpjsoniterscalacirce/CirceSupportSpec.scala
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjsoniterscalacirce
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.Marshal
+import org.apache.pekko.http.scaladsl.model.ContentTypes.{ `application/json`, `text/plain(UTF-8)` }
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import org.apache.pekko.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import com.github.pjfanning.pekkohttpcircebase.ErrorAccumulatingSupport
+import cats.data.{ NonEmptyList, ValidatedNel }
+import cats.implicits.toShow
+import io.circe.CursorOp.DownField
+import io.circe.{ DecodingFailure, ParsingFailure, Printer }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.{ BeforeAndAfterAll, EitherValues }
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+object CirceSupportSpec {
+
+  final case class Foo(bar: String) {
+    require(bar startsWith "bar", "bar must start with 'bar'!")
+  }
+
+  final case class MultiFoo(a: String, b: String)
+
+  final case class OptionFoo(a: Option[String])
+}
+
+final class CirceSupportSpec
+    extends AsyncWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with EitherValues {
+  import CirceSupportSpec._
+
+  private implicit val system: ActorSystem = ActorSystem()
+
+  private val `application/json-home` =
+    MediaType.applicationWithFixedCharset("json-home", HttpCharsets.`UTF-8`, "json-home")
+
+  /**
+    * Specs common to both [[FailFastCirceSupport]] and [[ErrorAccumulatingCirceSupport]]
+    */
+  private def commonCirceSupport(support: BaseCirceSupport): Unit = {
+    import io.circe.generic.auto._
+    import support._
+
+    "enable marshalling and unmarshalling objects for generic derivation" in {
+      val foo = Foo("bar")
+      Marshal(foo)
+        .to[RequestEntity]
+        .flatMap(Unmarshal(_).to[Foo])
+        .map(_ shouldBe foo)
+    }
+
+    "provide proper error messages for requirement errors" in {
+      val entity = HttpEntity(`application/json`, """{ "bar": "baz" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ should have message "requirement failed: bar must start with 'bar'!")
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(
+          _ shouldBe UnsupportedContentTypeException(Some(`text/plain(UTF-8)`), `application/json`)
+        )
+    }
+
+    "write None as null by default" in {
+      val optionFoo = OptionFoo(None)
+      Marshal(optionFoo)
+        .to[RequestEntity]
+        .map(_.asInstanceOf[HttpEntity.Strict].data.decodeString("UTF-8") shouldBe "{\"a\":null}")
+    }
+
+    "not write None" in {
+      implicit val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
+      val optionFoo                 = OptionFoo(None)
+      Marshal(optionFoo)
+        .to[RequestEntity]
+        .map(_.asInstanceOf[HttpEntity.Strict].data.decodeString("UTF-8") shouldBe "{}")
+    }
+  }
+
+  "FailFastCirceSupport" should {
+    import FailFastCirceSupport._
+    import io.circe.generic.auto._
+
+    behave like commonCirceSupport(FailFastCirceSupport)
+
+    "fail with a ParsingFailure when unmarshalling empty entities with safeUnmarshaller" in {
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Either[io.circe.Error, Foo]]
+        .futureValue
+        .left
+        .value shouldBe a[ParsingFailure]
+    }
+
+    "fail-fast and return only the first unmarshalling error" in {
+      val entity = HttpEntity(`application/json`, """{ "a": 1, "b": 2 }""")
+      val error =
+        DecodingFailure("Got value '1' with wrong type, expecting string", List(DownField("a")))
+      Unmarshal(entity)
+        .to[MultiFoo]
+        .failed
+        .map(_.getMessage shouldBe error.getMessage())
+    }
+
+    "fail-fast and return only the first unmarshalling error with safeUnmarshaller" in {
+      val entity = HttpEntity(`application/json`, """{ "a": 1, "b": 2 }""")
+      val error: io.circe.Error =
+        DecodingFailure("Got value '1' with wrong type, expecting string", List(DownField("a")))
+      Unmarshal(entity)
+        .to[Either[io.circe.Error, MultiFoo]]
+        .futureValue
+        .left
+        .value
+        .getMessage shouldBe error.getMessage
+    }
+
+    "allow unmarshalling with passed in Content-Types" in {
+      val foo = Foo("bar")
+
+      final object CustomCirceSupport extends FailFastCirceSupport {
+        override def unmarshallerContentTypes: List[ContentTypeRange] =
+          List(`application/json`, `application/json-home`)
+      }
+      import CustomCirceSupport._
+
+      val entity = HttpEntity(`application/json`, """{ "bar": "bar" }""")
+      Unmarshal(entity).to[Foo].map(_ shouldBe foo)
+    }
+  }
+
+  "ErrorAccumulatingCirceSupport" should {
+    import ErrorAccumulatingCirceSupport._
+    import io.circe.generic.auto._
+
+    behave like commonCirceSupport(ErrorAccumulatingCirceSupport)
+
+    "fail with a NonEmptyList of Errors when unmarshalling empty entities with safeUnmarshaller" in {
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[ValidatedNel[io.circe.Error, Foo]]
+        .futureValue
+        .toEither
+        .left
+        .value shouldBe a[NonEmptyList[_]]
+    }
+
+    "accumulate and return all unmarshalling errors" in {
+      val entity = HttpEntity(`application/json`, """{ "a": 1, "b": 2 }""")
+      val errors =
+        NonEmptyList.of(
+          DecodingFailure("Got value '1' with wrong type, expecting string", List(DownField("a"))),
+          DecodingFailure("Got value '2' with wrong type, expecting string", List(DownField("b")))
+        )
+      val errorMessage = ErrorAccumulatingSupport.DecodingFailures(errors).getMessage
+      Unmarshal(entity)
+        .to[MultiFoo]
+        .failed
+        .map(_.getMessage shouldBe errorMessage)
+    }
+
+    "accumulate and return all unmarshalling errors with safeUnmarshaller" in {
+      val entity = HttpEntity(`application/json`, """{ "a": 1, "b": 2 }""")
+      val errors: NonEmptyList[DecodingFailure] =
+        NonEmptyList.of(
+          DecodingFailure("Got value '1' with wrong type, expecting string", List(DownField("a"))),
+          DecodingFailure("Got value '2' with wrong type, expecting string", List(DownField("b")))
+        )
+      val errorMessage = ErrorAccumulatingSupport.DecodingFailures(errors).getMessage
+      val result: String = Unmarshal(entity)
+        .to[ValidatedNel[io.circe.Error, MultiFoo]]
+        .futureValue
+        .toEither
+        .left
+        .value
+        .collect { case df: DecodingFailure =>
+          df.show
+        }
+        .mkString("\n")
+
+      errorMessage shouldBe result
+    }
+
+    "allow unmarshalling with passed in Content-Types" in {
+      val foo = Foo("bar")
+
+      final object CustomCirceSupport extends ErrorAccumulatingCirceSupport {
+        override def unmarshallerContentTypes: List[ContentTypeRange] =
+          List(`application/json`, `application/json-home`)
+      }
+      import CustomCirceSupport._
+
+      val entity = HttpEntity(`application/json-home`, """{ "bar": "bar" }""")
+      Unmarshal(entity).to[Foo].map(_ shouldBe foo)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    Await.ready(system.terminate(), 42.seconds)
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
This pull request proposes adding a module that uses the [jsoniter-scala-circe](https://github.com/plokhotnyuk/jsoniter-scala/tree/1e1ea2fc3d1df823cc842ef65c96065584f916c6/jsoniter-scala-circe) booster for parsing into the `Json` data type instead of Circe's parser.

This was designed to be an in-place replacement of pekko-http-circe. As such, this introduces the pekko-http-circe-base module that is not published as its own artifact but contains all the common traits that are shared between pekko-http-circe and pekko-http-jsoniter-scala-circe.

I have some open questions regarding this:
* In the process of moving common code into pekko-http-circe-base, the location of `DecodingFailures` (which is public) changed. Is that OK or should we expose a different type for pekko-http-circe and pekko-http-jsoniter-scala-circe?
* Should we have the current copyright notice in new source files?
* I tried to avoid replication on the module's source, but ended up copying the same spec from pekko-http-circe into pekko-http-jsoniter-scala-circe. Is that OK or should we try to factor out some commonalities?