### PR TITLE
zio-json: decode directly instead of via a ZIO stream

### DIFF
--- a/pekko-http-zio-json/src/main/scala/com/github/pjfanning/pekkohttpziojson/ZioJsonSupport.scala
+++ b/pekko-http-zio-json/src/main/scala/com/github/pjfanning/pekkohttpziojson/ZioJsonSupport.scala
@@ -39,8 +39,6 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 import zio.json._
-import zio.stream.ZStream
-import zio.Unsafe
 
 object ZioJsonSupport extends ZioJsonSupport
 
@@ -103,9 +101,14 @@ trait ZioJsonSupport {
       jd: JsonDecoder[A],
       rt: zio.Runtime[Any]
   ): Unmarshaller[ByteString, A] =
-    Unmarshaller { _ => bs =>
-      val decoded = jd.decodeJsonStreamInput(ZStream.fromIterable(bs))
-      Unsafe.unsafeCompat(implicit u => rt.unsafe.runToFuture(decoded))
+    Unmarshaller { ec => bs =>
+      // `rt` is no longer used but is kept for source and binary compatibility
+      Future {
+        jd.decodeJson(bs.utf8String) match {
+          case Right(a)  => a
+          case Left(err) => throw new Exception(err)
+        }
+      }(ec)
     }
 
   /**


### PR DESCRIPTION
`ZioJsonSupport.fromByteStringUnmarshaller` fed the request body to zio-json's
*streaming* decoder:

```scala
val decoded = jd.decodeJsonStreamInput(ZStream.fromIterable(bs))
Unsafe.unsafeCompat(implicit u => rt.unsafe.runToFuture(decoded))
```

`ByteString` is an `IndexedSeq[Byte]`, so `ZStream.fromIterable` walks its
boxing iterator to build a `Chunk`, the streaming parser runs, and the result is
pulled back out of the ZIO runtime with `runToFuture` — once per request, and
once per element in `sourceUnmarshaller`.

`JsonDecoder.decodeJson` on the UTF-8 string skips all three costs.

### Numbers

Decoding a 21KB body (500-element array of a 3-field case class), 200 iterations
after warmup, steady state:

| decode path | ms/op |
| --- | --- |
| `ZStream.fromIterable(bs)` (before) | 1.86 |
| `ZStream.fromChunk(Chunk.fromArray(bs.toArrayUnsafe()))` | 1.37 |
| `jd.decodeJson(bs.utf8String)` (after) | 0.22 |

Un-boxing alone gets ~25%; dropping the streaming decoder and the runtime
round-trip gets ~8x.

### Compatibility

The implicit `zio.Runtime` parameter is now unused but is kept, so the signature
stays source and binary compatible.

Behaviour is unchanged. Failures still surface as a failed `Future` holding a
plain `java.lang.Exception` whose message is zio-json's error string — that is
what the stream decoder produced too. I compared both paths over trailing
garbage, concatenated values, leading/trailing whitespace, a BOM, unknown
fields, non-ASCII escapes, a wrong top-level type, `null`, and empty input: the
results are identical except that empty input reports `Unexpected end of input`
rather than `unexpected end of input`. The entity unmarshaller throws
`NoContentException` before an empty body reaches the decoder, so that casing
difference is only reachable by calling `fromByteStringUnmarshaller` directly.

Tests pass on 2.12.21, 2.13.18 and 3.3.8.

`main` carries the identical file, so the same change applies there — happy to
follow up with a port.
