### PR TITLE
Resolve the element unmarshaller once per streaming operation

### DIFF
--- a/pekko-http-argonaut/src/main/scala/com/github/pjfanning/pekkohttpargonaut/ArgonautSupport.scala
+++ b/pekko-http-argonaut/src/main/scala/com/github/pjfanning/pekkohttpargonaut/ArgonautSupport.scala
@@ -26,11 +26,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -161,8 +157,11 @@ trait ArgonautSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
+++ b/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
@@ -21,11 +21,7 @@ import org.apache.pekko.http.scaladsl.common.EntityStreamingSupport
 import org.apache.pekko.http.scaladsl.marshalling.{ Marshaller, Marshalling, ToEntityMarshaller }
 import org.apache.pekko.http.scaladsl.model._
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -163,8 +159,11 @@ trait AvroSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-circe-base/src/main/scala/com/github/pjfanning/pekkohttpcircebase/BaseSupport.scala
+++ b/pekko-http-circe-base/src/main/scala/com/github/pjfanning/pekkohttpcircebase/BaseSupport.scala
@@ -27,11 +27,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MediaType,
   MessageEntity
 }
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -166,8 +162,11 @@ trait BaseSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
+++ b/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
@@ -41,11 +41,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -240,8 +236,11 @@ trait JacksonSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupport.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupport.scala
@@ -40,11 +40,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -230,8 +226,11 @@ trait JacksonSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-json4s/src/main/scala/com/github/pjfanning/pekkohttpjson4s/Json4sSupport.scala
+++ b/pekko-http-json4s/src/main/scala/com/github/pjfanning/pekkohttpjson4s/Json4sSupport.scala
@@ -26,11 +26,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
@@ -187,8 +183,11 @@ trait Json4sSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
+++ b/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
@@ -27,11 +27,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -152,8 +148,11 @@ trait JsoniterScalaSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
+++ b/pekko-http-ninny/src/main/scala/com/github/pjfanning/pekkohttpninny/NinnySupport.scala
@@ -26,11 +26,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -113,8 +109,11 @@ trait NinnySupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
+++ b/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
@@ -155,8 +155,11 @@ trait PlayJsonSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-upickle/src/main/scala/com/github/pjfanning/pekkohttpupickle/UpickleCustomizationSupport.scala
+++ b/pekko-http-upickle/src/main/scala/com/github/pjfanning/pekkohttpupickle/UpickleCustomizationSupport.scala
@@ -27,11 +27,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -146,8 +142,11 @@ trait UpickleCustomizationSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)

--- a/pekko-http-zio-json/src/main/scala/com/github/pjfanning/pekkohttpziojson/ZioJsonSupport.scala
+++ b/pekko-http-zio-json/src/main/scala/com/github/pjfanning/pekkohttpziojson/ZioJsonSupport.scala
@@ -27,11 +27,7 @@ import org.apache.pekko.http.scaladsl.model.{
   MessageEntity
 }
 import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
-import org.apache.pekko.http.scaladsl.unmarshalling.{
-  FromEntityUnmarshaller,
-  Unmarshal,
-  Unmarshaller
-}
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
@@ -156,8 +152,11 @@ trait ZioJsonSupport {
   ): FromEntityUnmarshaller[SourceOf[A]] =
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]
+
         def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
+          elementUnmarshaller(bs)
 
         def ordered =
           Flow[ByteString].mapAsync(support.parallelism)(asyncParse)


### PR DESCRIPTION
Every `sourceUnmarshaller` parsed stream elements like this:

```scala
def asyncParse(bs: ByteString) =
  Unmarshal(bs).to[A]
```

`to[A]` takes an implicit `Unmarshaller[ByteString, A]`, which resolves to the
module's own `fromByteStringUnmarshaller[A]` — an `implicit def`. Implicit
arguments are inserted at the call site, so that method ran, and allocated a
fresh `Unmarshaller`, once per element of the stream. Resolving it once outside
`asyncParse` is enough:

```scala
// resolved once per unmarshalling operation rather than once per stream element
val elementUnmarshaller = implicitly[Unmarshaller[ByteString, A]]

def asyncParse(bs: ByteString) =
  elementUnmarshaller(bs)
```

Applied to all 11 modules that have a `sourceUnmarshaller`. `Unmarshal` is no
longer referenced anywhere in the main sources, so its import is dropped too.

### This is a cleanup, not a speedup

I benchmarked it rather than assuming. Streaming 5000 elements through
`mapAsync`, jsoniter-scala module, 20 iterations after warmup:

| | ms per 5000 elements |
| --- | --- |
| per-element (before) | 33.1, 35.5 |
| hoisted (after) | 35.2, 36.0 |

That is noise. The allocation removed is two small closures against a
per-element cost of roughly 7µs that is dominated by the `Future` and the stream
stage. Worth having because it says what it means and does strictly less work,
but nobody should expect a throughput change.

Behaviour is unchanged: the same implicit resolves to the same unmarshaller,
just once instead of N times. Tests pass on 2.12.21, 2.13.18 and 3.3.8.
