### PR TITLE
Wrap freshly serialized arrays without copying them

### DIFF
--- a/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
+++ b/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
@@ -83,14 +83,14 @@ trait AvroSupport {
       support: JsonEntityStreamingSupport
   ): SourceOf[ByteString] =
     entitySource
+      // toByteArray returns a fresh array, so it can be wrapped without copying
       .map { obj =>
         val baos   = new ByteArrayOutputStream()
         val stream = AvroOutputStream.json[A].to(baos).build()
         stream.write(obj)
         stream.close()
-        baos.toByteArray
+        ByteString.fromArrayUnsafe(baos.toByteArray)
       }
-      .map(ByteString(_))
       .via(support.framingRenderer)
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] = defaultContentTypes

--- a/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
+++ b/pekko-http-jackson/src/main/scala/com/github/pjfanning/pekkohttpjackson/JacksonSupport.scala
@@ -177,8 +177,8 @@ trait JacksonSupport {
       support: JsonEntityStreamingSupport
   ): SourceOf[ByteString] =
     entitySource
-      .map(objectMapper.writeValueAsBytes)
-      .map(ByteString(_))
+      // writeValueAsBytes returns a fresh array, so it can be wrapped without copying
+      .map(a => ByteString.fromArrayUnsafe(objectMapper.writeValueAsBytes(a)))
       .via(support.framingRenderer)
 
   /**

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupport.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupport.scala
@@ -167,8 +167,8 @@ trait JacksonSupport {
       support: JsonEntityStreamingSupport
   ): SourceOf[ByteString] =
     entitySource
-      .map(objectMapper.writeValueAsBytes)
-      .map(ByteString(_))
+      // writeValueAsBytes returns a fresh array, so it can be wrapped without copying
+      .map(a => ByteString.fromArrayUnsafe(objectMapper.writeValueAsBytes(a)))
       .via(support.framingRenderer)
 
   /**

--- a/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
+++ b/pekko-http-jsoniter-scala/src/main/scala/com/github/pjfanning/pekkohttpjsoniterscala/JsoniterScalaSupport.scala
@@ -90,8 +90,8 @@ trait JsoniterScalaSupport {
       support: JsonEntityStreamingSupport
   ): SourceOf[ByteString] =
     entitySource
-      .map(writeToArray(_, config))
-      .map(ByteString(_))
+      // writeToArray returns a fresh array, so it can be wrapped without copying
+      .map(a => ByteString.fromArrayUnsafe(writeToArray(a, config)))
       .via(support.framingRenderer)
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] = defaultContentTypes


### PR DESCRIPTION
`jsonSource` serialized each stream element to an `Array[Byte]` and then wrapped
it:

```scala
entitySource
  .map(writeToArray(_, config))
  .map(ByteString(_))
```

`ByteString.apply(Array[Byte])` builds a `CompactByteString` by copying the
array. Every one of these arrays comes straight out of `writeValueAsBytes`,
`writeToArray` or `ByteArrayOutputStream.toByteArray`, is freshly allocated, and
is never touched again — so `ByteString.fromArrayUnsafe` can take ownership and
skip the copy:

```scala
entitySource
  // writeToArray returns a fresh array, so it can be wrapped without copying
  .map(a => ByteString.fromArrayUnsafe(writeToArray(a, config)))
```

The single-value `marshaller` in the jsoniter-scala and avro4s modules already
does exactly this; the streaming paths just never got the same treatment.

### Scope

Only the four modules that serialize to `Array[Byte]`: jackson, jackson3,
jsoniter-scala and avro4s.

The other seven were left alone deliberately. argonaut, json4s, ninny,
play-json, upickle and zio-json produce a `String`, where the encode to bytes is
unavoidable. circe produces a `ByteBuffer` from `Printer.printToByteBuffer`,
whose backing array is sized by the charset encoder's worst case and so is
generally larger than the encoded content — reaching for `.array()` there would
append garbage.

### Numbers

Streaming 5000 elements through `framingRenderer`, 10 iterations after warmup,
steady state:

| element size | `ByteString(_)` | `fromArrayUnsafe` |
| --- | --- | --- |
| 21 B | 2.28 ms | 2.01 ms |
| 4830 B | 77.1 ms | 71.2 ms |

Roughly 8-12%, and the direction was consistent across every round.

Tests pass on 2.12.21, 2.13.18 and 3.3.8.
