### PR TITLE
play-json and json4s: parse the entity bytes instead of a String

### DIFF
--- a/pekko-http-json4s/src/main/scala/com/github/pjfanning/pekkohttpjson4s/Json4sSupport.scala
+++ b/pekko-http-json4s/src/main/scala/com/github/pjfanning/pekkohttpjson4s/Json4sSupport.scala
@@ -36,8 +36,9 @@ import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
 import com.github.pjfanning.pekkohttpjson4s.Json4sSupport.ShouldWritePretty.False
-import org.json4s.{ Formats, MappingException, Serialization }
+import org.json4s.{ Formats, MappingException, ReaderInput, Serialization }
 
+import java.io.InputStreamReader
 import java.lang.reflect.InvocationTargetException
 import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
@@ -74,12 +75,14 @@ trait Json4sSupport {
   private val defaultMediaTypes: Seq[MediaType.WithFixedCharset] = List(`application/json`)
   def mediaTypes: Seq[MediaType.WithFixedCharset]                = defaultMediaTypes
 
-  private val jsonStringUnmarshaller =
+  private val jsonInputUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(unmarshallerContentTypes: _*)
       .mapWithCharset {
         case (ByteString.empty, _) => throw Unmarshaller.NoContentException
-        case (data, charset)       => data.decodeString(charset.nioCharset.name)
+        // reading from the bytes avoids materialising the whole entity as a String
+        case (data, charset) =>
+          ReaderInput(new InputStreamReader(data.asInputStream, charset.nioCharset))
       }
 
   private val jsonStringMarshaller =
@@ -130,8 +133,8 @@ trait Json4sSupport {
       serialization: Serialization,
       formats: Formats
   ): FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller
-      .map(s => serialization.read(s))
+    jsonInputUnmarshaller
+      .map(input => serialization.read(input))
       .recover(throwCause)
 
   /**

--- a/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
+++ b/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
@@ -32,6 +32,8 @@ import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
 import play.api.libs.json.{ JsError, JsResultException, JsValue, Json, Reads, Writes }
 
+import java.nio.charset.StandardCharsets
+
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -60,12 +62,17 @@ trait PlayJsonSupport {
   private val defaultMediaTypes: Seq[MediaType.WithFixedCharset] = List(`application/json`)
   def mediaTypes: Seq[MediaType.WithFixedCharset]                = defaultMediaTypes
 
-  private val jsonStringUnmarshaller =
+  private val jsonValueUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(unmarshallerContentTypes: _*)
       .mapWithCharset {
-        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
-        case (data, charset)       => data.decodeString(charset.nioCharset.name)
+        case (ByteString.empty, _) =>
+          throw Unmarshaller.NoContentException
+        case (data, charset) if charset.nioCharset == StandardCharsets.UTF_8 =>
+          // parsing the bytes avoids materialising the whole entity as a String
+          Json.parse(data.asInputStream)
+        case (data, charset) =>
+          Json.parse(data.decodeString(charset.nioCharset))
       }
 
   private def sourceByteStringMarshaller(
@@ -115,7 +122,7 @@ trait PlayJsonSupport {
     *   unmarshaller for `A`
     */
   implicit def unmarshaller[A: Reads]: FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller.map(data => read(Json.parse(data)))
+    jsonValueUnmarshaller.map(json => read[A](json))
 
   /**
     * `A` => HTTP entity


### PR DESCRIPTION
Both entity unmarshallers materialised the whole entity as a `String` first:

```scala
.mapWithCharset {
  case (ByteString.empty, _) => throw Unmarshaller.NoContentException
  case (data, charset)       => data.decodeString(charset.nioCharset.name)
}
```

and then handed that `String` to a parser that is perfectly happy with bytes.
play-json now parses the entity's `InputStream` — which is what its own
`fromByteStringUnmarshaller` already did — and json4s reads through a
`ReaderInput` over the bytes.

json4s goes through a `Reader` rather than an `InputStream` so that the charset
declared by the content type is still honoured. play-json has no `Reader`
overload, so it keeps the `String` path for the non-UTF-8 case and takes the
byte path only when the charset is UTF-8 (which is what `application/json`
fixes it to).

`ReaderInput` is applied explicitly rather than relying on json4s's implicit
`Reader => JsonInput` conversion, which Scala 3 does not apply to an overloaded
`read`.

### Numbers

Parsing a payload of N records, 300 iterations after warmup, steady state:

**play-json**

| payload | `decodeString` + `parse(String)` | `parse(InputStream)` |
| --- | --- | --- |
| 433 B | 0.086 ms | 0.075 ms |
| 46 KB | 2.12 ms | 1.66 ms |

**json4s** (jackson backend)

| payload | `decodeString` + `read(String)` | `read(ReaderInput)` |
| --- | --- | --- |
| 433 B | 0.119 ms | 0.082 ms |
| 46 KB | 2.66 ms | 2.62 ms |

json4s-native behaves the same way, a little narrower.

### Modules deliberately left alone

I measured the other String-decoding modules before touching them, and they do
not benefit:

- **jackson / jackson3** — `readValue(bytes)` came in ~2% ahead at 46 KB and
  behind at 433 B. Inside noise; not worth the churn.
- **upickle** — reading from `Array[Byte]` was consistently *slower* than from a
  `String` (46 KB: 0.54 ms via String vs 0.96 ms via bytes). Its
  `fromByteStringUnmarshaller` currently takes the byte path, so there may be a
  win in going the other direction there; that needs its own measurement in the
  streaming context and is not part of this PR.
- **argonaut** — `Parse.parse` only accepts a `String`.

Tests pass on 2.12.21, 2.13.18 and 3.3.8.
