### PR TITLE
play-json: marshal compact JSON by default

### DIFF
--- a/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
+++ b/pekko-http-play-json/src/main/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupport.scala
@@ -127,6 +127,10 @@ trait PlayJsonSupport {
   /**
     * `A` => HTTP entity
     *
+    * Output is compact. Pretty printing, which used to be the default, costs roughly 1.5x the
+    * response bytes and 15-25% more CPU; put an implicit `JsValue => String` in scope - for
+    * instance `implicit val printer: JsValue => String = Json.prettyPrint` - to get it back.
+    *
     * @tparam A
     *   type to encode
     * @return
@@ -134,7 +138,7 @@ trait PlayJsonSupport {
     */
   implicit def marshaller[A](implicit
       writes: Writes[A],
-      printer: JsValue => String = Json.prettyPrint
+      printer: JsValue => String = Json.stringify
   ): ToEntityMarshaller[A] =
     jsonStringMarshaller.compose(printer).compose(writes.writes)
 

--- a/pekko-http-play-json/src/test/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupportSpec.scala
+++ b/pekko-http-play-json/src/test/scala/com/github/pjfanning/pekkohttpplayjson/PlayJsonSupportSpec.scala
@@ -26,7 +26,7 @@ import org.apache.pekko.stream.scaladsl.{ Sink, Source }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-import play.api.libs.json.{ Format, Json }
+import play.api.libs.json.{ Format, JsValue, Json }
 import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
@@ -54,6 +54,24 @@ final class PlayJsonSupportSpec extends AsyncWordSpec with Matchers with BeforeA
         .to[RequestEntity]
         .flatMap(Unmarshal(_).to[Foo])
         .map(_ shouldBe foo)
+    }
+
+    "marshal to compact json by default" in
+    Marshal(Foo("bar"))
+      .to[RequestEntity]
+      .map(_.asInstanceOf[HttpEntity.Strict].data.utf8String shouldBe """{"bar":"bar"}""")
+
+    "marshal to pretty json when a printer is in scope" in {
+      implicit val printer: JsValue => String = Json.prettyPrint
+
+      val expected =
+        """|{
+           |  "bar" : "bar"
+           |}""".stripMargin
+
+      Marshal(Foo("bar"))
+        .to[RequestEntity]
+        .map(_.asInstanceOf[HttpEntity.Strict].data.utf8String shouldBe expected)
     }
 
     "enable streamed marshalling and unmarshalling for json arrays" in {


### PR DESCRIPTION
`PlayJsonSupport.marshaller` has defaulted to `Json.prettyPrint` since the
original akka-http-json:

```scala
implicit def marshaller[A](implicit
    writes: Writes[A],
    printer: JsValue => String = Json.prettyPrint
): ToEntityMarshaller[A] =
```

so every response this module writes is indented, unless the caller supplies a
printer. This changes that default to `Json.stringify`.

### Why

Pretty printing is not free, measured on a payload of N records, 2000
iterations after warmup:

| payload | `prettyPrint` | `stringify` | size ratio |
| --- | --- | --- | --- |
| 1 record | 11.4 µs | 8.3-9.5 µs | 66 vs 44 chars (1.50x) |
| 1000 records | 834 µs | 721 µs | 67788 vs 46787 chars (1.45x) |

Roughly 1.5x the bytes on the wire and 15-25% more CPU, on every response.

It is also the odd one out. The streaming marshaller in this same file already
defaults to `Json.stringify`, json4s defaults to `ShouldWritePretty.False` and
circe to `Printer.noSpaces` — play-json is the only module here that indents by
default.

### This is a behaviour change

Response bodies become compact. Anything asserting on exact response bytes will
need updating. Pretty printing is restored by putting an implicit printer in
scope:

```scala
implicit val printer: JsValue => String = Json.prettyPrint
```

which is what the module's own `ExampleApp` already does, and what the new
`marshal to pretty json when a printer is in scope` test demonstrates. A second
test pins the new compact default.

Source and binary compatible — only the body of the synthesized default-argument
method changes, not any signature.

Tests pass on 2.12.21, 2.13.18 and 3.3.8.
