### PR TITLE
avro4s: build the Avro schema once, and close the input stream

### DIFF
--- a/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
+++ b/pekko-http-avro4s/src/main/scala/com/github/pjfanning/pekkohttpavro4s/AvroSupport.scala
@@ -105,19 +105,18 @@ trait AvroSupport {
     * @return
     *   unmarshaller for any `A` value
     */
-  implicit def fromByteStringUnmarshaller[A: SchemaFor: Decoder]: Unmarshaller[ByteString, A] =
+  implicit def fromByteStringUnmarshaller[A: SchemaFor: Decoder]: Unmarshaller[ByteString, A] = {
+    // building the schema is expensive, so it is done once rather than per value decoded
+    val schema = AvroSchema[A]
     Unmarshaller { ec => bs =>
       Future {
-        val schema = AvroSchema[A]
         if (bs.isEmpty) throw Unmarshaller.NoContentException
-        AvroInputStream
-          .json[A]
-          .from(bs.asInputStream)
-          .build(schema)
-          .iterator
-          .next()
+        val in = AvroInputStream.json[A].from(bs.asInputStream).build(schema)
+        try in.iterator.next()
+        finally in.close()
       }(ec)
     }
+  }
 
   /**
     * HTTP entity => `A`
@@ -126,7 +125,9 @@ trait AvroSupport {
     val schema = AvroSchema[A]
     byteArrayUnmarshaller.map { bytes =>
       if (bytes.isEmpty) throw Unmarshaller.NoContentException
-      AvroInputStream.json[A].from(bytes).build(schema).iterator.next()
+      val in = AvroInputStream.json[A].from(bytes).build(schema)
+      try in.iterator.next()
+      finally in.close()
     }
   }
 


### PR DESCRIPTION
`fromByteStringUnmarshaller` built the Avro schema inside the `Future`:

```scala
Unmarshaller { ec => bs =>
  Future {
    val schema = AvroSchema[A]
    ...
  }(ec)
}
```

so it was rebuilt for every value decoded. `unmarshaller`, right below it,
already hoists the same call out of the decode; this brings the two in line.

### Numbers

`AvroSchema[Foo]` on its own costs **17.3 µs**, which dominates decoding
anything small. 20000 iterations after warmup, steady state:

| | schema per decode | schema hoisted |
| --- | --- | --- |
| 40 B record | 29.7 µs | 4.3 µs |
| 4828 B record | 74.2 µs | 49.7 µs |

7x on a small record, 1.5x on a 4.8 KB one.

### Interaction with #296

This is per *value decoded*, and `sourceUnmarshaller` decodes one value per
stream element. On `3.x` as it stands, `Unmarshal(bs).to[A]` re-invokes
`fromByteStringUnmarshaller[A]` for every element, so hoisting the schema into
that method only helps once per element — no better than today.

#296 resolves the element unmarshaller once per unmarshalling operation, which
is what makes this hoist actually hold across a stream. Merged together, avro4s
streaming builds the schema once per request instead of once per element. #296
measured as no better than noise on its own; this is the change that pays it off.

### Also: the input stream is now closed

`AvroInputStream ... .build(schema).iterator.next()` never closed the stream, in
either method. Both now use try/finally. The underlying source is a
`ByteArrayInputStream`, so nothing was leaking at the OS level, but the avro
decoder was being dropped on the floor rather than released.

Tests pass on 2.12.21 and 2.13.18 (this module is not cross-built for Scala 3).
