### PR TITLE
Add a pekko-http-fory-json-scala module

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,4 @@
 -Xmx2g
--XX:MaxMetaspaceSize=1g
 -XX:ReservedCodeCacheSize=256m
 -XX:+UseParallelGC
 -Dfile.encoding=UTF8

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pekko-http-json provides JSON (un)marshalling support for [Apache Pekko HTTP](ht
 - [avro4s](https://github.com/sksamuel/avro4s)
 - [AVSystem GenCodec](https://github.com/AVSystem/scala-commons/blob/master/docs/GenCodec.md)
 - [circe](https://circe.github.io/circe/)
+- [Fory JSON](https://fory.apache.org) via [fory-json-scala](https://github.com/apache/fory)
 - [Jackson](https://github.com/FasterXML/jackson) via [Scala Module](https://github.com/FasterXML/jackson-module-scala) by default
   - pekko-http-jackson v2.0.x supports Jackson 2.14
   - pekko-http-jackson v2.1.x supports Jackson 2.15

--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ lazy val `pekko-http-json` =
       `pekko-http-avro4s`,
       `pekko-http-circe`,
       `pekko-http-circe-base`,
+      `pekko-http-fory-json-scala`,
       `pekko-http-jackson`,
       `pekko-http-jackson3`,
       `pekko-http-json4s`,
@@ -120,6 +121,18 @@ lazy val `pekko-http-circe-base` =
         Library.pekkoHttp,
         Library.circe,
         Library.pekkoStream % Provided
+      )
+    )
+
+lazy val `pekko-http-fory-json-scala` =
+  project
+    .settings(commonSettings, withScala3)
+    .settings(
+      libraryDependencies ++= Seq(
+        Library.pekkoHttp,
+        Library.foryJsonScala,
+        Library.pekkoStream % Provided,
+        Library.scalaTest   % Test,
       )
     )
 

--- a/pekko-http-fory-json-scala/src/main/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupport.scala
+++ b/pekko-http-fory-json-scala/src/main/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupport.scala
@@ -116,7 +116,9 @@ trait ForyJsonSupport {
       support: JsonEntityStreamingSupport
   ): SourceOf[ByteString] =
     entitySource
-      .map(a => ByteString(foryJson.toJson(a, typeRef)))
+      // toJsonBytes returns a fresh array, so it can be wrapped without copying, and it avoids
+      // materialising each element as a String on the way
+      .map(a => ByteString.fromArrayUnsafe(foryJson.toJsonBytes(a, typeRef)))
       .via(support.framingRenderer)
 
   /**
@@ -151,7 +153,7 @@ trait ForyJsonSupport {
     val mediaType   = mediaTypes.head
     val contentType = ContentType.WithFixedCharset(mediaType)
     Marshaller.withFixedContentType(contentType) { obj =>
-      HttpEntity.Strict(contentType, ByteString(foryJson.toJson(obj, typeRef)))
+      HttpEntity.Strict(contentType, ByteString.fromArrayUnsafe(foryJson.toJsonBytes(obj, typeRef)))
     }
   }
 

--- a/pekko-http-fory-json-scala/src/main/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupport.scala
+++ b/pekko-http-fory-json-scala/src/main/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupport.scala
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpforyjsonscala
+
+import org.apache.pekko.http.javadsl.common.JsonEntityStreamingSupport
+import org.apache.pekko.http.scaladsl.common.EntityStreamingSupport
+import org.apache.pekko.http.scaladsl.marshalling.{ Marshaller, Marshalling, ToEntityMarshaller }
+import org.apache.pekko.http.scaladsl.model.{
+  ContentType,
+  ContentTypeRange,
+  HttpEntity,
+  MediaType,
+  MessageEntity
+}
+import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
+import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
+import org.apache.pekko.http.scaladsl.util.FastFuture
+import org.apache.pekko.stream.scaladsl.{ Flow, Source }
+import org.apache.pekko.util.ByteString
+import org.apache.fory.json.ForyJson
+import org.apache.fory.json.scala.ForyJsonScala
+import org.apache.fory.reflect.TypeRef
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+/**
+  * Automatic to and from JSON marshalling/unmarshalling using an in-scope Fory `TypeRef`.
+  *
+  * A `TypeRef` is obtained with `ScalaTypeRef`, which keeps Scala type arguments that JVM erasure
+  * would otherwise lose:
+  *
+  * {{{
+  * implicit val fooTypeRef: TypeRef[Foo] = ScalaTypeRef[Foo]
+  * }}}
+  *
+  * Note that Fory does not populate the fields of a case class declared inside an `object`; such a
+  * value decodes with all of its fields left null rather than failing. Declare the types you
+  * exchange over HTTP at the top level of a file.
+  */
+object ForyJsonSupport extends ForyJsonSupport {
+
+  /**
+    * The `ForyJson` used when none is in implicit scope. It has the Scala module installed, so
+    * Scala collections, options and enumerations are understood.
+    */
+  val defaultForyJson: ForyJson = ForyJsonScala.builder().build()
+}
+
+/**
+  * JSON marshalling/unmarshalling using Fory's JSON support.
+  *
+  * Every marshaller and unmarshaller takes the `ForyJson` to use as an implicit parameter,
+  * defaulting to [[ForyJsonSupport.defaultForyJson]]. Put your own in scope to configure Fory -
+  * naming strategy, null handling, and the parsing limits worth setting for untrusted input:
+  *
+  * {{{
+  * implicit val foryJson: ForyJson =
+  *   ForyJsonScala
+  *     .builder()
+  *     .maxDepth(32)
+  *     .withMaxGraphMemoryBytes(8 * 1024 * 1024)
+  *     .build()
+  * }}}
+  */
+trait ForyJsonSupport {
+  type SourceOf[A] = Source[A, _]
+
+  import ForyJsonSupport._
+
+  private val defaultMediaTypes: Seq[MediaType.WithFixedCharset] = List(`application/json`)
+  private val defaultContentTypes: Seq[ContentTypeRange]         =
+    defaultMediaTypes.map(ContentTypeRange.apply)
+
+  def unmarshallerContentTypes: Seq[ContentTypeRange] = defaultContentTypes
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] = defaultMediaTypes
+
+  private val byteArrayUnmarshaller: FromEntityUnmarshaller[Array[Byte]] =
+    Unmarshaller.byteArrayUnmarshaller.forContentTypes(unmarshallerContentTypes: _*)
+
+  private def sourceByteStringMarshaller(
+      mediaType: MediaType.WithFixedCharset
+  ): Marshaller[SourceOf[ByteString], MessageEntity] =
+    Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
+      try
+        FastFuture.successful {
+          Marshalling.WithFixedContentType(
+            mediaType,
+            () => HttpEntity(contentType = mediaType, data = value)
+          ) :: Nil
+        }
+      catch {
+        case NonFatal(e) => FastFuture.failed(e)
+      }
+    }
+
+  private val jsonSourceStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(sourceByteStringMarshaller)
+
+  private def jsonSource[A](entitySource: SourceOf[A])(implicit
+      typeRef: TypeRef[A],
+      foryJson: ForyJson,
+      support: JsonEntityStreamingSupport
+  ): SourceOf[ByteString] =
+    entitySource
+      .map(a => ByteString(foryJson.toJson(a, typeRef)))
+      .via(support.framingRenderer)
+
+  /**
+    * HTTP entity => `A`
+    *
+    * @tparam A
+    *   type to decode
+    * @return
+    *   unmarshaller for `A`
+    */
+  implicit def unmarshaller[A](implicit
+      typeRef: TypeRef[A],
+      foryJson: ForyJson = defaultForyJson
+  ): FromEntityUnmarshaller[A] =
+    byteArrayUnmarshaller.map { bytes =>
+      if (bytes.length == 0) throw Unmarshaller.NoContentException
+      foryJson.fromJson(bytes, typeRef)
+    }
+
+  /**
+    * `A` => HTTP entity
+    *
+    * @tparam A
+    *   type to encode
+    * @return
+    *   marshaller for any `A` value
+    */
+  implicit def marshaller[A](implicit
+      typeRef: TypeRef[A],
+      foryJson: ForyJson = defaultForyJson
+  ): ToEntityMarshaller[A] = {
+    val mediaType   = mediaTypes.head
+    val contentType = ContentType.WithFixedCharset(mediaType)
+    Marshaller.withFixedContentType(contentType) { obj =>
+      HttpEntity.Strict(contentType, ByteString(foryJson.toJson(obj, typeRef)))
+    }
+  }
+
+  /**
+    * `ByteString` => `A`
+    *
+    * @tparam A
+    *   type to decode
+    * @return
+    *   unmarshaller for any `A` value
+    */
+  implicit def fromByteStringUnmarshaller[A](implicit
+      typeRef: TypeRef[A],
+      foryJson: ForyJson = defaultForyJson
+  ): Unmarshaller[ByteString, A] =
+    Unmarshaller(ec => bs => Future(foryJson.fromJson(bs.asInputStream, typeRef))(ec))
+
+  /**
+    * HTTP entity => `Source[A, _]`
+    *
+    * @tparam A
+    *   type to decode
+    * @return
+    *   unmarshaller for `Source[A, _]`
+    */
+  implicit def sourceUnmarshaller[A](implicit
+      typeRef: TypeRef[A],
+      foryJson: ForyJson = defaultForyJson,
+      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): FromEntityUnmarshaller[SourceOf[A]] =
+    Unmarshaller
+      .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        // resolved once per unmarshalling operation rather than once per stream element
+        val elementUnmarshaller = fromByteStringUnmarshaller[A]
+
+        def asyncParse(bs: ByteString) =
+          elementUnmarshaller(bs)
+
+        def ordered =
+          Flow[ByteString].mapAsync(support.parallelism)(asyncParse)
+
+        def unordered =
+          Flow[ByteString].mapAsyncUnordered(support.parallelism)(asyncParse)
+
+        Future.successful {
+          entity.dataBytes
+            .via(support.framingDecoder)
+            .via(if (support.unordered) unordered else ordered)
+        }
+      }
+      .forContentTypes(unmarshallerContentTypes: _*)
+
+  /**
+    * `SourceOf[A]` => HTTP entity
+    *
+    * @tparam A
+    *   type to encode
+    * @return
+    *   marshaller for any `SourceOf[A]` value
+    */
+  implicit def sourceMarshaller[A](implicit
+      typeRef: TypeRef[A],
+      foryJson: ForyJson = defaultForyJson,
+      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): ToEntityMarshaller[SourceOf[A]] =
+    jsonSourceStringMarshaller.compose(jsonSource[A])
+}

--- a/pekko-http-fory-json-scala/src/test/scala/com/github/pjfanning/pekkohttpforyjsonscala/ExampleApp.scala
+++ b/pekko-http-fory-json-scala/src/test/scala/com/github/pjfanning/pekkohttpforyjsonscala/ExampleApp.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpforyjsonscala
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.http.scaladsl.server.{ Directives, Route }
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.fory.json.scala.ScalaTypeRef
+import org.apache.fory.reflect.TypeRef
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.io.StdIn
+
+// declared at the top level: Fory leaves the fields of a case class nested in an `object` unset
+final case class ExampleFoo(bar: String)
+
+object ExampleApp {
+
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem()
+
+    Http().newServerAt("127.0.0.1", 8000).bindFlow(route)
+
+    StdIn.readLine("Hit ENTER to exit")
+    Await.ready(system.terminate(), Duration.Inf)
+  }
+
+  def route(implicit sys: ActorSystem): Route = {
+    import Directives._
+    import ForyJsonSupport._
+
+    // a TypeRef is needed for every type exchanged over HTTP
+    implicit val fooTypeRef: TypeRef[ExampleFoo] = ScalaTypeRef[ExampleFoo]
+
+    // you can also put your own ForyJson in scope to override the default one, for instance
+    //
+    // implicit val foryJson: ForyJson = ForyJsonScala.builder().maxDepth(32).build()
+
+    pathSingleSlash {
+      post {
+        entity(as[ExampleFoo]) { foo =>
+          complete {
+            foo
+          }
+        }
+      }
+    } ~ pathPrefix("stream") {
+      post {
+        entity(as[SourceOf[ExampleFoo]]) { (fooSource: SourceOf[ExampleFoo]) =>
+          complete(fooSource.throttle(1, 2.seconds))
+        }
+      } ~ get {
+        pathEndOrSingleSlash {
+          complete(
+            Source(0 to 5)
+              .throttle(1, 1.seconds)
+              .map(i => ExampleFoo(s"bar-$i"))
+          )
+        } ~ pathPrefix("remote") {
+          onSuccess(Http().singleRequest(HttpRequest(uri = "http://localhost:8000/stream"))) {
+            response => complete(Unmarshal(response).to[SourceOf[ExampleFoo]])
+          }
+        }
+      }
+    }
+  }
+}

--- a/pekko-http-fory-json-scala/src/test/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupportSpec.scala
+++ b/pekko-http-fory-json-scala/src/test/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupportSpec.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpforyjsonscala
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.Marshal
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.ContentTypes.{ `application/json`, `text/plain(UTF-8)` }
+import org.apache.pekko.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import org.apache.fory.json.{ ForyJson, PropertyNamingStrategy }
+import org.apache.fory.json.scala.{ ForyJsonScala, ScalaTypeRef }
+import org.apache.fory.reflect.TypeRef
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+// Fory leaves the fields of a case class declared inside an `object` unset, so the types used here
+// are declared at the top level rather than in a companion object like the other modules' specs.
+final case class Foo(bar: String)
+
+final case class SnakeFoo(barBaz: String)
+
+final class ForyJsonSupportSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll {
+  import ForyJsonSupport._
+
+  private implicit val system: ActorSystem      = ActorSystem()
+  private implicit val fooTypeRef: TypeRef[Foo] = ScalaTypeRef[Foo]
+
+  "ForyJsonSupport" should {
+    "enable marshalling and unmarshalling of case classes" in {
+      val foo = Foo("bar")
+      Marshal(foo)
+        .to[RequestEntity]
+        .flatMap(Unmarshal(_).to[Foo])
+        .map(_ shouldBe foo)
+    }
+
+    "marshal to compact json" in
+    Marshal(Foo("bar"))
+      .to[RequestEntity]
+      .map(_.asInstanceOf[HttpEntity.Strict].data.utf8String shouldBe """{"bar":"bar"}""")
+
+    "enable streamed marshalling and unmarshalling for json arrays" in {
+      val foos = (0 to 100).map(i => Foo(s"bar-$i")).toList
+
+      Marshal(Source(foos))
+        .to[RequestEntity]
+        .flatMap(entity => Unmarshal(entity).to[SourceOf[Foo]])
+        .flatMap(_.runWith(Sink.seq))
+        .map(_ shouldBe foos)
+    }
+
+    "use a ForyJson provided in implicit scope" in {
+      implicit val snakeCaseFory: ForyJson = ForyJsonScala
+        .builder()
+        .withPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+        .build()
+      implicit val snakeFooTypeRef: TypeRef[SnakeFoo] = ScalaTypeRef[SnakeFoo]
+
+      Marshal(SnakeFoo("baz"))
+        .to[RequestEntity]
+        .map(_.asInstanceOf[HttpEntity.Strict].data.utf8String shouldBe """{"bar_baz":"baz"}""")
+    }
+
+    "unmarshal with a ForyJson provided in implicit scope" in {
+      implicit val snakeCaseFory: ForyJson = ForyJsonScala
+        .builder()
+        .withPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+        .build()
+      implicit val snakeFooTypeRef: TypeRef[SnakeFoo] = ScalaTypeRef[SnakeFoo]
+
+      val entity = HttpEntity(`application/json`, """{"bar_baz":"baz"}""")
+      Unmarshal(entity).to[SnakeFoo].map(_ shouldBe SnakeFoo("baz"))
+    }
+
+    "use the default ForyJson when none is in scope" in {
+      implicit val snakeFooTypeRef: TypeRef[SnakeFoo] = ScalaTypeRef[SnakeFoo]
+
+      Marshal(SnakeFoo("baz"))
+        .to[RequestEntity]
+        .map(_.asInstanceOf[HttpEntity.Strict].data.utf8String shouldBe """{"barBaz":"baz"}""")
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(
+          _ shouldBe UnsupportedContentTypeException(Some(`text/plain(UTF-8)`), `application/json`)
+        )
+    }
+
+    "allow unmarshalling with passed in Content-Types" in {
+      val foo                     = Foo("bar")
+      val `application/json-home` =
+        MediaType.applicationWithFixedCharset("json-home", HttpCharsets.`UTF-8`, "json-home")
+
+      object CustomForyJsonSupport extends ForyJsonSupport {
+        override def unmarshallerContentTypes: Seq[ContentTypeRange] =
+          List(`application/json`, `application/json-home`)
+      }
+      import CustomForyJsonSupport._
+
+      val entity = HttpEntity(`application/json-home`, """{ "bar": "bar" }""")
+      Unmarshal(entity).to[Foo].map(_ shouldBe foo)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    Await.ready(system.terminate(), 42.seconds)
+    super.afterAll()
+  }
+}

--- a/project/Library.scala
+++ b/project/Library.scala
@@ -8,6 +8,7 @@ object Library {
     val argonaut      = "6.3.13"
     val avro4s        = "4.1.2"
     val circe         = "0.14.16"
+    val fory          = "1.7.0"
     val jackson2      = "2.22.2"
     val jackson3      = "3.2.2"
     val json4s        = "4.1.1"
@@ -26,6 +27,7 @@ object Library {
   val circe                = "io.circe"                              %% "circe-core"            % Version.circe
   val circeGeneric         = "io.circe"                              %% "circe-generic"         % Version.circe
   val circeParser          = "io.circe"                              %% "circe-parser"          % Version.circe
+  val foryJsonScala        = "org.apache.fory"                       %% "fory-json-scala"       % Version.fory
   val jacksonModuleScala2  = "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % Version.jackson2
   val jacksonModuleParamNames2 = "com.fasterxml.jackson.module"       % "jackson-module-parameter-names" % Version.jackson2
   val jacksonModuleScala3  = "tools.jackson.module"                  %% "jackson-module-scala"  % Version.jackson3


### PR DESCRIPTION
Port of #301 to `main`.

`ForyJsonSupport` marshals and unmarshals via Apache Fory's JSON support, using
the Scala module from `fory-json-scala` so Scala collections, options and
enumerations are understood. Types are identified by an implicit
`org.apache.fory.reflect.TypeRef`:

```scala
implicit val fooTypeRef: TypeRef[Foo] = ScalaTypeRef[Foo]
```

and the `ForyJson` itself is an implicit parameter defaulting to
`defaultForyJson`, so your own instance in scope wins — which is how you reach
Fory's `maxDepth`, `withMaxGraphMemoryBytes` and `withBufferSizeLimitBytes`.

The module source, spec and example app are unchanged from #301.

### Adjustments for main

- **No `crossScalaVersions` override.** `main` already builds 2.13 by default
  with `withScala3` opting into 3.3.8, which is exactly what this module needs.
  The `scala213AndScala3` value that `3.x` required — where the build defaults
  to 2.12 and 2.13, and there is no `fory-json-scala_2.12` — is not needed here
  and is gone.
- **No `targetJava8`.** `main` has no per-module Java target split; the release
  target lives in `commonSettings`.
- **`.jvmopts`: `-XX:MaxMetaspaceSize` removed rather than raised.** The 1g cap
  failed a cold CI build on `3.x` once a fifteenth module was added — every test
  passed and then sbt died with `OutOfMemoryError: Metaspace`, because Fory
  generates code at runtime. On `3.x` I raised the cap to 2g; here the cap is
  dropped instead, which is what sbt's own error message recommends and what the
  JVM already defaults to (`MaxMetaspaceSize` reports as unbounded on Java 17).
  `main` also cross-builds two Scala versions rather than three, so it is under
  less pressure to begin with.

### Verification

The module's own tests pass locally on 2.13.18 and 3.3.8, against main's
pekko 2.0.0-M4 / pekko-http 2.0.0-M1. Leaving the full matrix to CI.
