### PR TITLE
fory-json-scala: serialize to bytes rather than through a String

### DIFF
--- a/pekko-http-fory-json-scala/src/main/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupport.scala
+++ b/pekko-http-fory-json-scala/src/main/scala/com/github/pjfanning/pekkohttpforyjsonscala/ForyJsonSupport.scala
@@ -116,7 +116,9 @@ trait ForyJsonSupport {
       support: JsonEntityStreamingSupport
   ): SourceOf[ByteString] =
     entitySource
-      .map(a => ByteString(foryJson.toJson(a, typeRef)))
+      // toJsonBytes returns a fresh array, so it can be wrapped without copying, and it avoids
+      // materialising each element as a String on the way
+      .map(a => ByteString.fromArrayUnsafe(foryJson.toJsonBytes(a, typeRef)))
       .via(support.framingRenderer)
 
   /**
@@ -151,7 +153,7 @@ trait ForyJsonSupport {
     val mediaType   = mediaTypes.head
     val contentType = ContentType.WithFixedCharset(mediaType)
     Marshaller.withFixedContentType(contentType) { obj =>
-      HttpEntity.Strict(contentType, ByteString(foryJson.toJson(obj, typeRef)))
+      HttpEntity.Strict(contentType, ByteString.fromArrayUnsafe(foryJson.toJsonBytes(obj, typeRef)))
     }
   }
 


### PR DESCRIPTION
`ForyJson.toJson` returns a `String`, so both marshallers were doing
object -> String -> UTF-8 encode -> copy into a `ByteString`:

```scala
ByteString(foryJson.toJson(a, typeRef))
```

`ForyJson` also has `toJsonBytes(T, TypeRef[T]): Array[Byte]`, which skips the
String entirely, and the array it returns is freshly allocated so
`fromArrayUnsafe` can take it without a copy:

```scala
ByteString.fromArrayUnsafe(foryJson.toJsonBytes(a, typeRef))
```

I missed `toJsonBytes` when writing the module — my javap filter hid exactly
those lines.

### Numbers

| payload | `toJson` + `ByteString` | `toJsonBytes` + `fromArrayUnsafe` |
| --- | --- | --- |
| 40 B | 0.50 µs | 0.45 µs |
| 42 KB | 152.75 µs | 98.18 µs |

### Streaming was tried and rejected

Fory also has `writeJsonTo(T, TypeRef[T], OutputStream)`, which in principle
avoids the intermediate array as well. I benchmarked it against `toJsonBytes`,
writing into a `ByteArrayOutputStream` subclass that can hand its buffer over as
a `ByteString` without copying (the `ByteStringOutputStream` pattern from
apache/pekko-http#1235). Best of 8 rounds:

| | `toJsonBytes` | `writeJsonTo` cap 64 | cap 8k | cap 64k |
| --- | --- | --- | --- | --- |
| 40 B | 0.27 µs | 0.23 µs | — | — |
| 42 KB | 53.03 µs | 55.68 µs | 52.16 µs | 66.28 µs |

It wins on tiny payloads and is a wash on large ones, and it is sensitive to the
buffer capacity in both directions — a 64KB buffer is materially *worse* than
growing from 64 bytes, because the allocation costs more than the copies it
saves. That is a new class plus a payload-dependent constant to tune, for no
reliable gain, so this PR keeps the one-line `toJsonBytes` change instead.

### Read path unchanged

`fromJson(InputStream)` versus `fromJson(byte[])` measured as noise on a 42KB
payload (152.57 / 159.02 µs against 149.01 / 177.34 µs), so
`fromByteStringUnmarshaller` is left alone.

Tests pass on 2.13.18 and 3.3.8.
