### PR TITLE
Add CBOR support to pekko-http-jackson3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ pekko-http-json provides JSON (un)marshalling support for [Apache Pekko HTTP](ht
   - pekko-http-jackson v2.3.x supports Jackson 2.16
     - pekko-http-jackson uses the default Jackson constraints (including some new to Jackson 2.16) but you can override them by overriding the configs in [reference.conf](https://github.com/pjfanning/pekko-http-json/blob/main/pekko-http-jackson/src/main/resources/reference.conf)
   - pekko-http-jackson v2.5.x supports Jackson 2.17
+  - pekko-http-jackson3 supports [Jackson 3](https://github.com/FasterXML/jackson-3) and, as well as
+    JSON, can marshal and unmarshal [CBOR](https://cbor.io) - see below
 - [Json4s](https://github.com/json4s/json4s)
 - [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala)
 - [ninny](https://nrktkt.github.io/ninny-json/USERGUIDE)
@@ -56,6 +58,34 @@ resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repos
 ## Usage
 
 Use respective support trait or object, e.g. `ArgonautSupport`, `FailFastCirceSupport`, etc. into your Pekko HTTP code which is supposed to (un)marshal from/to JSON. Don't forget to provide the type class instances for the respective JSON libraries, if needed.
+
+### CBOR with pekko-http-jackson3
+
+`pekko-http-jackson3` marshals to JSON by default. It can marshal to CBOR instead, either for the
+whole application:
+
+``` hocon
+pekko-http-json.jackson.format = "cbor"
+```
+
+or for the routes you pick, by importing `CborSupport` (or `JsonSupport`, which stays on JSON
+whatever the config says) instead of `JacksonSupport`:
+
+``` scala
+import com.github.pjfanning.pekkohttpjackson3.CborSupport._
+```
+
+Either way, entities are marshalled to and unmarshalled from `application/cbor`, and the
+`pekko-http-json.jackson.read` and `write` settings apply just as they do to JSON. The
+`jackson-dataformat-cbor` jar is an optional dependency of `pekko-http-jackson3`, so add it to your
+build to use CBOR:
+
+``` scala
+libraryDependencies += "tools.jackson.dataformat" % "jackson-dataformat-cbor" % "3.2.2"
+```
+
+The `Source` based streaming marshallers frame their output as a JSON array, so they remain
+JSON only; they throw an `UnsupportedOperationException` when the data format is CBOR.
 
 ## Contribution policy ##
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+
 // *****************************************************************************
 // Build settings
 // *****************************************************************************
@@ -201,11 +203,28 @@ lazy val `pekko-http-jackson3` =
     .settings(commonSettings, targetJava17, withScala3)
     .settings(mimaSettingsSince("3.1.0"))
     .settings(
+      // `mediaTypes` was widened from Seq[MediaType.WithFixedCharset] to Seq[MediaType] so that it
+      // can also hold the binary `application/cbor`. The erased signature is unchanged, and the
+      // wider type still accepts every override that compiled against the old one.
+      mimaBinaryIssueFilters += ProblemFilters.exclude[IncompatibleSignatureProblem](
+        "com.github.pjfanning.pekkohttpjackson3.JacksonSupport*.mediaTypes"
+      ),
+      // 3.1.0 had no `defaultObjectMapper` in the JacksonSupport trait - the no-arg static of that
+      // name in the trait's interface was an artifact of the trait's `import JacksonSupport._`,
+      // uncallable from Scala. It is now a real member, so that the mapper can follow `dataFormat`.
+      mimaBinaryIssueFilters += ProblemFilters.exclude[StaticVirtualMemberProblem](
+        "com.github.pjfanning.pekkohttpjackson3.JacksonSupport.defaultObjectMapper"
+      )
+    )
+    .settings(
       libraryDependencies ++= Seq(
         Library.pekkoHttp,
         Library.jacksonModuleScala3,
-        Library.pekkoStream % Provided,
-        Library.scalaTest   % Test
+        // only needed for `pekko-http-json.jackson.format = cbor` / `CborSupport`, so it is left
+        // for users of those to pull in themselves
+        Library.jacksonDataformatCbor3 % Optional,
+        Library.pekkoStream            % Provided,
+        Library.scalaTest              % Test
       )
     )
 

--- a/pekko-http-jackson3/src/main/resources/reference.conf
+++ b/pekko-http-jackson3/src/main/resources/reference.conf
@@ -1,6 +1,14 @@
 pekko-http-json {
   jackson {
     jackson-modules += "tools.jackson.module.scala.DefaultScalaModule"
+
+    # The data format that JacksonSupport marshals to and unmarshals from.
+    # The supported values are "json" and "cbor".
+    # "cbor" needs `tools.jackson.dataformat:jackson-dataformat-cbor` on the classpath - it is an
+    # optional dependency of this library. The read/write settings below apply to both formats.
+    # The format can also be chosen in code, by overriding `JacksonSupport.dataFormat` or by using
+    # the ready made `JsonSupport` and `CborSupport` objects.
+    format = "json"
     read {
       # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.18.0/com/fasterxml/jackson/core/StreamReadConstraints.html
       # these defaults are the same as the defaults in `StreamReadConstraints`

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/CborConfigSupport.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/CborConfigSupport.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjackson3
+
+import com.typesafe.config.Config
+import tools.jackson.core.StreamReadFeature
+import tools.jackson.databind.{ DeserializationFeature, ObjectMapper }
+import tools.jackson.dataformat.cbor.{ CBORFactory, CBORMapper }
+import tools.jackson.module.scala.ClassTagExtensions
+
+/**
+  * CBOR flavour of [[JacksonConfigSupport]].
+  *
+  * `jackson-dataformat-cbor` is an optional dependency, so every reference to it is confined to
+  * this object - nothing here is loaded unless [[JacksonDataFormat.Cbor]] is actually used.
+  */
+private[pekkohttpjackson3] object CborConfigSupport {
+
+  def createCborFactory(config: Config): CBORFactory =
+    CBORFactory
+      .builder()
+      .streamReadConstraints(JacksonConfigSupport.streamReadConstraints(config))
+      .streamWriteConstraints(JacksonConfigSupport.streamWriteConstraints(config))
+      .recyclerPool(JacksonConfigSupport.bufferRecyclerPool(config))
+      .configure(
+        StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION,
+        JacksonConfigSupport.includeSourceInLocation(config)
+      )
+      .build()
+
+  def createCborObjectMapper(config: Config): ObjectMapper with ClassTagExtensions = {
+    val builder = CBORMapper.builder(createCborFactory(config))
+    builder.disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+    JacksonConfigSupport.modules(config).foreach(builder.addModule)
+    builder.build() :: ClassTagExtensions
+  }
+}

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/CborSupport.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/CborSupport.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjackson3
+
+/**
+  * [[JacksonSupport]] pinned to CBOR, whatever `pekko-http-json.jackson.format` is set to.
+  *
+  * Entities are marshalled to, and unmarshalled from, `application/cbor`. This needs
+  * `tools.jackson.dataformat:jackson-dataformat-cbor` on the classpath - it is an optional
+  * dependency of this library:
+  *
+  * {{{
+  * libraryDependencies += "tools.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
+  * }}}
+  */
+object CborSupport extends CborSupport
+
+trait CborSupport extends JacksonSupport {
+  final override def dataFormat: JacksonDataFormat = JacksonDataFormat.Cbor
+}

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonConfigSupport.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonConfigSupport.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjackson3
+
+import com.typesafe.config.{ Config, ConfigFactory }
+import tools.jackson.core.util.{ BufferRecycler, JsonRecyclerPools, RecyclerPool }
+import tools.jackson.core.{ StreamReadConstraints, StreamReadFeature, StreamWriteConstraints }
+import tools.jackson.core.json.{ JsonFactory, JsonFactoryBuilder }
+import tools.jackson.databind.{ DeserializationFeature, JacksonModule, ObjectMapper }
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.scala.ClassTagExtensions
+
+import scala.util.Try
+
+/**
+  * The parts of the `pekko-http-json.jackson` config that are not specific to any one data format.
+  *
+  * This lives outside of [[JacksonSupport]] so that reading the config does not depend on that
+  * object having finished initialising - the trait it extends asks for the configured data format
+  * while the object is still being constructed.
+  */
+private[pekkohttpjackson3] object JacksonConfigSupport {
+
+  val jacksonConfig: Config = ConfigFactory.load().getConfig("pekko-http-json.jackson")
+
+  def streamReadConstraints(config: Config): StreamReadConstraints =
+    StreamReadConstraints
+      .builder()
+      .maxNestingDepth(config.getInt("read.max-nesting-depth"))
+      .maxNumberLength(config.getInt("read.max-number-length"))
+      .maxStringLength(config.getInt("read.max-string-length"))
+      .maxNameLength(config.getInt("read.max-name-length"))
+      .maxDocumentLength(config.getInt("read.max-document-length"))
+      .maxTokenCount(config.getInt("read.max-token-count"))
+      .build()
+
+  def streamWriteConstraints(config: Config): StreamWriteConstraints =
+    StreamWriteConstraints
+      .builder()
+      .maxNestingDepth(config.getInt("write.max-nesting-depth"))
+      .build()
+
+  def includeSourceInLocation(config: Config): Boolean =
+    config.getBoolean("read.feature.include-source-in-location")
+
+  def bufferRecyclerPool(config: Config): RecyclerPool[BufferRecycler] =
+    config.getString("buffer-recycler.pool-instance") match {
+      case "thread-local"            => JsonRecyclerPools.threadLocalPool()
+      case "concurrent-deque"        => JsonRecyclerPools.newConcurrentDequePool()
+      case "shared-concurrent-deque" => JsonRecyclerPools.sharedConcurrentDequePool()
+      case "bounded"                 =>
+        JsonRecyclerPools.newBoundedPool(config.getInt("buffer-recycler.bounded-pool-size"))
+      case "non-recycling" => JsonRecyclerPools.nonRecyclingPool()
+      case other           => throw new IllegalArgumentException(s"Unknown recycler-pool: $other")
+    }
+
+  /** The modules named by `jackson-modules`, in the order they are configured. */
+  def modules(config: Config): List[JacksonModule] = {
+    import org.apache.pekko.util.ccompat.JavaConverters._
+    config.getStringList("jackson-modules").asScala.toList.map(loadModule)
+  }
+
+  def createJsonFactory(config: Config): JsonFactory = {
+    val jsonFactoryBuilder: JsonFactoryBuilder = JsonFactory
+      .builder()
+      .asInstanceOf[JsonFactoryBuilder]
+      .streamReadConstraints(streamReadConstraints(config))
+      .streamWriteConstraints(streamWriteConstraints(config))
+      .recyclerPool(bufferRecyclerPool(config))
+      .configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, includeSourceInLocation(config))
+    jsonFactoryBuilder.build()
+  }
+
+  def createJsonObjectMapper(config: Config): ObjectMapper with ClassTagExtensions = {
+    val builder = JsonMapper.builder(createJsonFactory(config))
+    builder.disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+    modules(config).foreach(builder.addModule)
+    builder.build() :: ClassTagExtensions
+  }
+
+  private def loadModule(fcqn: String): JacksonModule = {
+    val inst = Try(Class.forName(fcqn).getConstructor().newInstance())
+      .getOrElse(Class.forName(fcqn + "$").getConstructor().newInstance())
+    inst.asInstanceOf[JacksonModule]
+  }
+}

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonDataFormat.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonDataFormat.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjackson3
+
+import com.typesafe.config.Config
+import org.apache.pekko.http.scaladsl.model.{ MediaType, MediaTypes }
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.scala.ClassTagExtensions
+
+import java.util.Locale
+import scala.collection.immutable.Seq
+
+/**
+  * A data format that [[JacksonSupport]] can marshal to and unmarshal from.
+  *
+  * The format in use is read from the `pekko-http-json.jackson.format` config setting - `json`
+  * unless you override it - and can also be chosen in code by overriding
+  * [[JacksonSupport.dataFormat]]; [[JsonSupport]] and [[CborSupport]] do exactly that.
+  */
+sealed abstract class JacksonDataFormat(val name: String) {
+
+  /** The media type that entities of this format are marshalled to. */
+  def mediaType: MediaType
+
+  private[pekkohttpjackson3] def createObjectMapper(
+      config: Config
+  ): ObjectMapper with ClassTagExtensions
+
+  override def toString: String = name
+}
+
+object JacksonDataFormat {
+
+  /** JSON, via `tools.jackson.databind.json.JsonMapper`. */
+  case object Json extends JacksonDataFormat("json") {
+    override def mediaType: MediaType = MediaTypes.`application/json`
+
+    override private[pekkohttpjackson3] def createObjectMapper(
+        config: Config
+    ): ObjectMapper with ClassTagExtensions =
+      JacksonConfigSupport.createJsonObjectMapper(config)
+  }
+
+  /**
+    * CBOR, via `tools.jackson.dataformat.cbor.CBORMapper`.
+    *
+    * `tools.jackson.dataformat:jackson-dataformat-cbor` is an optional dependency of this library,
+    * so add it to your build before selecting this format.
+    */
+  case object Cbor extends JacksonDataFormat("cbor") {
+    override def mediaType: MediaType = MediaTypes.`application/cbor`
+
+    override private[pekkohttpjackson3] def createObjectMapper(
+        config: Config
+    ): ObjectMapper with ClassTagExtensions =
+      CborConfigSupport.createCborObjectMapper(config)
+  }
+
+  val values: Seq[JacksonDataFormat] = List(Json, Cbor)
+
+  /** The format configured by `pekko-http-json.jackson.format`. */
+  lazy val default: JacksonDataFormat = apply(
+    JacksonConfigSupport.jacksonConfig.getString("format")
+  )
+
+  /** @throws IllegalArgumentException if `name` does not name a supported format */
+  def apply(name: String): JacksonDataFormat =
+    values
+      .find(_.name == name.toLowerCase(Locale.ROOT))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"Unknown Jackson data format: '$name' (supported: ${values.map(_.name).mkString(", ")})"
+        )
+      )
+}

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupport.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupport.scala
@@ -16,38 +16,31 @@
 
 package com.github.pjfanning.pekkohttpjackson3
 
-import tools.jackson.core.util.{ BufferRecycler, JsonRecyclerPools, RecyclerPool }
-import tools.jackson.core.{
-  JsonParser,
-  ObjectReadContext,
-  StreamReadConstraints,
-  StreamReadFeature,
-  StreamWriteConstraints
-}
-import tools.jackson.core.json.{ JsonFactory, JsonFactoryBuilder }
+import tools.jackson.core.{ JsonParser, ObjectReadContext }
+import tools.jackson.core.json.JsonFactory
 import tools.jackson.core.async.ByteBufferFeeder
-import tools.jackson.databind.{ DeserializationFeature, JacksonModule, ObjectMapper }
-import tools.jackson.databind.json.JsonMapper
+import tools.jackson.databind.ObjectMapper
 import tools.jackson.module.scala.{ ClassTagExtensions, JavaTypeable }
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import org.apache.pekko.http.javadsl.common.JsonEntityStreamingSupport
 import org.apache.pekko.http.scaladsl.common.EntityStreamingSupport
 import org.apache.pekko.http.scaladsl.marshalling._
 import org.apache.pekko.http.scaladsl.model.{
+  ContentType,
   ContentTypeRange,
+  HttpCharsets,
   HttpEntity,
   MediaType,
   MessageEntity
 }
-import org.apache.pekko.http.scaladsl.model.MediaTypes.`application/json`
 import org.apache.pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import org.apache.pekko.http.scaladsl.util.FastFuture
 import org.apache.pekko.stream.scaladsl.{ Flow, Source }
 import org.apache.pekko.util.ByteString
 
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
-import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -55,81 +48,71 @@ import scala.util.control.NonFatal
   */
 object JacksonSupport extends JacksonSupport {
 
-  private[pekkohttpjackson3] val jacksonConfig =
-    ConfigFactory.load().getConfig("pekko-http-json.jackson")
+  private[pekkohttpjackson3] val jacksonConfig = JacksonConfigSupport.jacksonConfig
 
-  private[pekkohttpjackson3] def createJsonFactory(config: Config): JsonFactory = {
-    val streamReadConstraints = StreamReadConstraints
-      .builder()
-      .maxNestingDepth(config.getInt("read.max-nesting-depth"))
-      .maxNumberLength(config.getInt("read.max-number-length"))
-      .maxStringLength(config.getInt("read.max-string-length"))
-      .maxNameLength(config.getInt("read.max-name-length"))
-      .maxDocumentLength(config.getInt("read.max-document-length"))
-      .maxTokenCount(config.getInt("read.max-token-count"))
-      .build()
-    val streamWriteConstraints = StreamWriteConstraints
-      .builder()
-      .maxNestingDepth(config.getInt("write.max-nesting-depth"))
-      .build()
-    val jsonFactoryBuilder: JsonFactoryBuilder = JsonFactory
-      .builder()
-      .asInstanceOf[JsonFactoryBuilder]
-      .streamReadConstraints(streamReadConstraints)
-      .streamWriteConstraints(streamWriteConstraints)
-      .recyclerPool(getBufferRecyclerPool(config))
-      .configure(
-        StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION,
-        config.getBoolean("read.feature.include-source-in-location")
-      )
-    jsonFactoryBuilder.build()
-  }
+  private[pekkohttpjackson3] def createJsonFactory(config: Config): JsonFactory =
+    JacksonConfigSupport.createJsonFactory(config)
 
-  private def getBufferRecyclerPool(cfg: Config): RecyclerPool[BufferRecycler] =
-    cfg.getString("buffer-recycler.pool-instance") match {
-      case "thread-local"            => JsonRecyclerPools.threadLocalPool()
-      case "concurrent-deque"        => JsonRecyclerPools.newConcurrentDequePool()
-      case "shared-concurrent-deque" => JsonRecyclerPools.sharedConcurrentDequePool()
-      case "bounded"                 =>
-        JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"))
-      case "non-recycling" => JsonRecyclerPools.nonRecyclingPool()
-      case other           => throw new IllegalArgumentException(s"Unknown recycler-pool: $other")
-    }
+  private val objectMappers =
+    new ConcurrentHashMap[JacksonDataFormat, ObjectMapper with ClassTagExtensions]
 
-  val defaultObjectMapper: ObjectMapper with ClassTagExtensions = createObjectMapper(jacksonConfig)
+  /**
+    * The mapper used for `dataFormat` when none is passed in explicitly. Built from
+    * `pekko-http-json.jackson` on first use, and then reused.
+    */
+  def objectMapperFor(dataFormat: JacksonDataFormat): ObjectMapper with ClassTagExtensions =
+    objectMappers.computeIfAbsent(
+      dataFormat,
+      (format: JacksonDataFormat) => createObjectMapper(jacksonConfig, format)
+    )
+
+  override val defaultObjectMapper: ObjectMapper with ClassTagExtensions =
+    objectMapperFor(JacksonDataFormat.default)
 
   private[pekkohttpjackson3] def createObjectMapper(
       config: Config
-  ): ObjectMapper with ClassTagExtensions = {
-    val builder = JsonMapper.builder(createJsonFactory(config))
-    builder.disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
-    import org.apache.pekko.util.ccompat.JavaConverters._
-    val configuredModules = config.getStringList("jackson-modules").asScala.toSeq
-    val modules           = configuredModules.map(loadModule)
-    modules.foreach(builder.addModule)
-    builder.build() :: ClassTagExtensions
-  }
+  ): ObjectMapper with ClassTagExtensions =
+    createObjectMapper(config, JacksonDataFormat(config.getString("format")))
 
-  private def loadModule(fcqn: String): JacksonModule = {
-    val inst = Try(Class.forName(fcqn).getConstructor().newInstance())
-      .getOrElse(Class.forName(fcqn + "$").getConstructor().newInstance())
-    inst.asInstanceOf[JacksonModule]
-  }
+  private[pekkohttpjackson3] def createObjectMapper(
+      config: Config,
+      dataFormat: JacksonDataFormat
+  ): ObjectMapper with ClassTagExtensions =
+    dataFormat.createObjectMapper(config)
 }
 
 /**
-  * JSON marshalling/unmarshalling using an in-scope Jackson's ObjectMapper
+  * JSON marshalling/unmarshalling using an in-scope Jackson's ObjectMapper.
+  *
+  * The data format is [[JacksonDataFormat.Json]] unless `pekko-http-json.jackson.format` says
+  * otherwise; override [[dataFormat]] to pin a format regardless of the config, as [[JsonSupport]]
+  * and [[CborSupport]] do. The `Source` based streaming marshallers frame their output as a JSON
+  * array, so they are only available for [[JacksonDataFormat.Json]].
   */
 trait JacksonSupport {
   type SourceOf[A] = Source[A, _]
 
-  import JacksonSupport._
+  /** The data format to marshal to and unmarshal from. */
+  def dataFormat: JacksonDataFormat = JacksonDataFormat.default
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
     mediaTypes.map(ContentTypeRange.apply)
 
-  private val defaultMediaTypes: Seq[MediaType.WithFixedCharset] = List(`application/json`)
-  def mediaTypes: Seq[MediaType.WithFixedCharset]                = defaultMediaTypes
+  def mediaTypes: Seq[MediaType] = List(dataFormat.mediaType)
+
+  private def contentTypeOf(mediaType: MediaType): ContentType =
+    ContentType(mediaType, () => HttpCharsets.`UTF-8`)
+
+  /** The mapper used when there is no `ObjectMapper` in implicit scope. */
+  def defaultObjectMapper: ObjectMapper with ClassTagExtensions =
+    JacksonSupport.objectMapperFor(dataFormat)
+
+  private def requireJsonFormat(operation: String): Unit =
+    if (dataFormat != JacksonDataFormat.Json)
+      throw new UnsupportedOperationException(
+        s"$operation frames its output as a JSON array and is only supported for the json data " +
+        s"format, but the data format is ${dataFormat.name}"
+      )
 
   private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
@@ -139,21 +122,33 @@ trait JacksonSupport {
         case (data, charset)       => data.decodeString(charset.nioCharset)
       }
 
+  // a def rather than a val: a val would add an abstract accessor to the trait, breaking anything
+  // that already implements it
+  private def binaryUnmarshaller =
+    Unmarshaller.byteStringUnmarshaller
+      .forContentTypes(unmarshallerContentTypes: _*)
+      .map {
+        case ByteString.empty => throw Unmarshaller.NoContentException
+        case data             => data.toArrayUnsafe()
+      }
+
   private def sourceByteStringMarshaller(
-      mediaType: MediaType.WithFixedCharset
-  ): Marshaller[SourceOf[ByteString], MessageEntity] =
+      mediaType: MediaType
+  ): Marshaller[SourceOf[ByteString], MessageEntity] = {
+    val contentType = contentTypeOf(mediaType)
     Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
       try
         FastFuture.successful {
           Marshalling.WithFixedContentType(
-            mediaType,
-            () => HttpEntity(contentType = mediaType, data = value)
+            contentType,
+            () => HttpEntity(contentType = contentType, data = value)
           ) :: Nil
         }
       catch {
         case NonFatal(e) => FastFuture.failed(e)
       }
     }
+  }
 
   private val jsonSourceStringMarshaller =
     Marshaller.oneOf(mediaTypes: _*)(sourceByteStringMarshaller)
@@ -173,7 +168,12 @@ trait JacksonSupport {
   implicit def unmarshaller[A: JavaTypeable](implicit
       objectMapper: ObjectMapper with ClassTagExtensions = defaultObjectMapper
   ): FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller.map(data => objectMapper.readValue[A](data))
+    dataFormat match {
+      case JacksonDataFormat.Json =>
+        jsonStringUnmarshaller.map(data => objectMapper.readValue[A](data))
+      case _ =>
+        binaryUnmarshaller.map(data => objectMapper.readValue[A](data))
+    }
 
   /**
     * `A` => HTTP entity
@@ -181,7 +181,15 @@ trait JacksonSupport {
   implicit def marshaller[Object](implicit
       objectMapper: ObjectMapper = defaultObjectMapper
   ): ToEntityMarshaller[Object] =
-    Jackson.marshaller[Object](objectMapper)
+    dataFormat match {
+      case JacksonDataFormat.Json => Jackson.marshaller[Object](objectMapper)
+      case _                      =>
+        Marshaller
+          .oneOf(mediaTypes: _*)(mediaType =>
+            Marshaller.byteArrayMarshaller(contentTypeOf(mediaType))
+          )
+          .compose[Object](objectMapper.writeValueAsBytes)
+    }
 
   /**
     * `ByteString` => `A`
@@ -194,27 +202,36 @@ trait JacksonSupport {
   implicit def fromByteStringUnmarshaller[A: JavaTypeable](implicit
       objectMapper: ObjectMapper with ClassTagExtensions = defaultObjectMapper
   ): Unmarshaller[ByteString, A] =
-    Unmarshaller { ec => bs =>
-      Future {
-        val parser = objectMapper
-          .tokenStreamFactory()
-          .createNonBlockingByteBufferParser(ObjectReadContext.empty())
-          .asInstanceOf[JsonParser with ByteBufferFeeder]
-        try {
-          bs match {
-            case bs: ByteString.ByteStrings =>
-              bs.asByteBuffers.foreach(parser.feedInput)
-            case bytes =>
-              parser.feedInput(bytes.asByteBuffer)
-          }
-          objectMapper.readValue[A](parser)
-        } finally
-          parser.close()
-      }(ec)
+    dataFormat match {
+      case JacksonDataFormat.Json =>
+        Unmarshaller { ec => bs =>
+          Future {
+            val parser = objectMapper
+              .tokenStreamFactory()
+              .createNonBlockingByteBufferParser(ObjectReadContext.empty())
+              .asInstanceOf[JsonParser with ByteBufferFeeder]
+            try {
+              bs match {
+                case bs: ByteString.ByteStrings =>
+                  bs.asByteBuffers.foreach(parser.feedInput)
+                case bytes =>
+                  parser.feedInput(bytes.asByteBuffer)
+              }
+              objectMapper.readValue[A](parser)
+            } finally
+              parser.close()
+          }(ec)
+        }
+      case _ =>
+        Unmarshaller { ec => bs =>
+          Future(objectMapper.readValue[A](bs.toArrayUnsafe()))(ec)
+        }
     }
 
   /**
     * HTTP entity => `Source[A, _]`
+    *
+    * Only supported for [[JacksonDataFormat.Json]].
     *
     * @tparam A
     *   type to decode
@@ -223,7 +240,8 @@ trait JacksonSupport {
     */
   implicit def sourceUnmarshaller[A: JavaTypeable](implicit
       support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
-  ): FromEntityUnmarshaller[SourceOf[A]] =
+  ): FromEntityUnmarshaller[SourceOf[A]] = {
+    requireJsonFormat("Source unmarshalling")
     Unmarshaller
       .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
         // resolved once per unmarshalling operation rather than once per stream element
@@ -245,9 +263,12 @@ trait JacksonSupport {
         }
       }
       .forContentTypes(unmarshallerContentTypes: _*)
+  }
 
   /**
     * `SourceOf[A]` => HTTP entity
+    *
+    * Only supported for [[JacksonDataFormat.Json]].
     *
     * @tparam A
     *   type to encode
@@ -257,6 +278,8 @@ trait JacksonSupport {
   implicit def sourceMarshaller[A](implicit
       objectMapper: ObjectMapper = defaultObjectMapper,
       support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
-  ): ToEntityMarshaller[SourceOf[A]] =
+  ): ToEntityMarshaller[SourceOf[A]] = {
+    requireJsonFormat("Source marshalling")
     jsonSourceStringMarshaller.compose(jsonSource[A])
+  }
 }

--- a/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JsonSupport.scala
+++ b/pekko-http-jackson3/src/main/scala/com/github/pjfanning/pekkohttpjackson3/JsonSupport.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjackson3
+
+/**
+  * [[JacksonSupport]] pinned to JSON, whatever `pekko-http-json.jackson.format` is set to.
+  */
+object JsonSupport extends JsonSupport
+
+trait JsonSupport extends JacksonSupport {
+  final override def dataFormat: JacksonDataFormat = JacksonDataFormat.Json
+}

--- a/pekko-http-jackson3/src/test/scala/com/github/pjfanning/pekkohttpjackson3/CborSupportSpec.scala
+++ b/pekko-http-jackson3/src/test/scala/com/github/pjfanning/pekkohttpjackson3/CborSupportSpec.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjackson3
+
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.Marshal
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.ContentTypes.`text/plain(UTF-8)`
+import org.apache.pekko.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import tools.jackson.dataformat.cbor.{ CBORFactory, CBORMapper, CBORParser }
+import tools.jackson.module.scala.DefaultScalaModule
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+object CborSupportSpec {
+
+  final case class Foo(bar: String) {
+    require(bar startsWith "bar", "bar must start with 'bar'!")
+  }
+
+  val plainCborMapper: CBORMapper =
+    CBORMapper.builder().addModule(DefaultScalaModule).build()
+}
+
+final class CborSupportSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll {
+  import CborSupport._
+  import CborSupportSpec._
+
+  private implicit val system: ActorSystem = ActorSystem()
+
+  private val `application/cbor` = MediaTypes.`application/cbor`
+
+  "CborSupport" should {
+    "enable marshalling and unmarshalling of case classes" in {
+      val foo = Foo("bar")
+      Marshal(foo)
+        .to[RequestEntity]
+        .flatMap(Unmarshal(_).to[Foo])
+        .map(_ shouldBe foo)
+    }
+
+    "enable marshalling and unmarshalling of arrays of values" in {
+      val foo = Seq(Foo("bar"))
+      Marshal(foo)
+        .to[RequestEntity]
+        .flatMap(Unmarshal(_).to[Seq[Foo]])
+        .map(_ shouldBe foo)
+    }
+
+    "marshal to `application/cbor` entities that hold CBOR, not JSON" in {
+      val foo = Foo("bar")
+      Marshal(foo).to[RequestEntity].flatMap { entity =>
+        entity.contentType.mediaType shouldBe `application/cbor`
+        entity.toStrict(3.seconds).map { strict =>
+          val bytes = strict.data.toArray
+          // a CBOR document starts with a major type byte, never with the '{' of a JSON object
+          bytes.head should not be '{'.toByte
+          plainCborMapper.readValue(bytes, classOf[Foo]) shouldBe foo
+        }
+      }
+    }
+
+    "unmarshal CBOR written by a plain CBORMapper" in {
+      val foo    = Foo("bar")
+      val entity = HttpEntity(`application/cbor`, plainCborMapper.writeValueAsBytes(foo))
+      Unmarshal(entity).to[Foo].map(_ shouldBe foo)
+    }
+
+    "unmarshal from `ByteString`" in {
+      val foo = Foo("bar")
+      Unmarshal(ByteString(plainCborMapper.writeValueAsBytes(foo))).to[Foo].map(_ shouldBe foo)
+    }
+
+    "provide proper error messages for requirement errors" in {
+      val entity =
+        HttpEntity(`application/cbor`, plainCborMapper.writeValueAsBytes(Map("bar" -> "baz")))
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_.getMessage should include("requirement failed: bar must start with 'bar'!"))
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      val entity = HttpEntity.empty(ContentType(`application/cbor`, () => HttpCharsets.`UTF-8`))
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/cbor`" in {
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(
+          _ shouldBe UnsupportedContentTypeException(
+            Some(`text/plain(UTF-8)`),
+            ContentType(`application/cbor`, () => HttpCharsets.`UTF-8`)
+          )
+        )
+    }
+
+    "allow unmarshalling with passed in Content-Types" in {
+      val foo                     = Foo("bar")
+      val `application/cbor-home` =
+        MediaType.applicationBinary("cbor-home", MediaType.Compressible)
+
+      object CustomCborSupport extends CborSupport {
+        override def mediaTypes = List(`application/cbor`, `application/cbor-home`)
+      }
+      import CustomCborSupport._
+
+      val entity = HttpEntity(`application/cbor-home`, plainCborMapper.writeValueAsBytes(foo))
+      Unmarshal(entity).to[Foo].map(_ shouldBe foo)
+    }
+
+    "reject the JSON array framed streaming marshallers" in {
+      val marshalling = the[UnsupportedOperationException] thrownBy Marshal(
+        Source(List(Foo("bar")))
+      ).to[RequestEntity]
+      marshalling.getMessage should include("data format is cbor")
+
+      val unmarshalling = the[UnsupportedOperationException] thrownBy Unmarshal(
+        HttpEntity(`application/cbor`, ByteString.empty)
+      ).to[SourceOf[Foo]]
+      unmarshalling.getMessage should include("data format is cbor")
+    }
+
+    "use a CBOR backed ObjectMapper" in {
+      // `:: ClassTagExtensions` copies the mapper into a mixin subclass, so the CBOR flavour shows
+      // up in the token stream factory rather than in the mapper's own class
+      JacksonSupport
+        .objectMapperFor(JacksonDataFormat.Cbor)
+        .tokenStreamFactory() shouldBe a[CBORFactory]
+      CborSupport.dataFormat shouldBe JacksonDataFormat.Cbor
+      CborSupport.mediaTypes shouldEqual List(`application/cbor`)
+    }
+
+    "apply the configured stream read constraints to the CBOR factory" in {
+      val testCfg = ConfigFactory
+        .parseString("read.max-string-length=17")
+        .withFallback(JacksonSupport.jacksonConfig)
+      val factory = CborConfigSupport.createCborFactory(testCfg)
+      factory.streamReadConstraints().getMaxStringLength shouldEqual 17
+      factory.streamWriteConstraints().getMaxNestingDepth shouldEqual 1000
+      factory._getRecyclerPool().getClass.getSimpleName shouldEqual "ThreadLocalPool"
+    }
+
+    "load the configured Jackson modules into the CBOR mapper" in {
+      val mapper = CborConfigSupport.createCborObjectMapper(JacksonSupport.jacksonConfig)
+      import org.apache.pekko.util.ccompat.JavaConverters._
+      mapper.registeredModules.asScala.map(_.getClass) should contain(classOf[DefaultScalaModule])
+    }
+
+    "read CBOR specific parser features" in {
+      // proves the entity really went through the CBOR parser rather than the JSON one
+      val parser =
+        CborConfigSupport
+          .createCborFactory(JacksonSupport.jacksonConfig)
+          .createParser(
+            tools.jackson.core.ObjectReadContext.empty(),
+            plainCborMapper.writeValueAsBytes(Foo("bar"))
+          )
+      try parser shouldBe a[CBORParser]
+      finally parser.close()
+    }
+  }
+
+  override protected def afterAll() = {
+    Await.ready(system.terminate(), 42.seconds)
+    super.afterAll()
+  }
+}

--- a/pekko-http-jackson3/src/test/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupportSpec.scala
+++ b/pekko-http-jackson3/src/test/scala/com/github/pjfanning/pekkohttpjackson3/JacksonSupportSpec.scala
@@ -19,6 +19,8 @@ package com.github.pjfanning.pekkohttpjackson3
 import tools.jackson.core.StreamReadFeature
 import tools.jackson.core.util.JsonRecyclerPools.BoundedPool
 import tools.jackson.databind.json.JsonMapper
+import tools.jackson.core.json.JsonFactory
+import tools.jackson.dataformat.cbor.CBORFactory
 import tools.jackson.module.scala.DefaultScalaModule
 import com.typesafe.config.ConfigFactory
 import org.apache.pekko.actor.ActorSystem
@@ -160,6 +162,30 @@ final class JacksonSupportSpec extends AsyncWordSpec with Matchers with BeforeAn
         .builder(testFactory)
         .build()
         .isEnabled(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION) shouldBe true
+    }
+
+    "default the data format to json" in {
+      JacksonSupport.jacksonConfig.getString("format") shouldEqual "json"
+      JacksonDataFormat.default shouldBe JacksonDataFormat.Json
+      JacksonSupport.dataFormat shouldBe JacksonDataFormat.Json
+      JsonSupport.dataFormat shouldBe JacksonDataFormat.Json
+      JacksonSupport.mediaTypes shouldEqual List(MediaTypes.`application/json`)
+      JacksonSupport.defaultObjectMapper shouldBe a[JsonMapper]
+    }
+
+    "build the mapper named by pekko-http-json.jackson.format" in {
+      val cborCfg = ConfigFactory
+        .parseString("""format = "cbor"""")
+        .withFallback(JacksonSupport.jacksonConfig)
+      JacksonSupport.createObjectMapper(cborCfg).tokenStreamFactory() shouldBe a[CBORFactory]
+      JacksonSupport
+        .createObjectMapper(JacksonSupport.jacksonConfig)
+        .tokenStreamFactory() shouldBe a[JsonFactory]
+    }
+
+    "reject an unknown pekko-http-json.jackson.format" in {
+      val thrown = the[IllegalArgumentException] thrownBy JacksonDataFormat("yaml")
+      thrown.getMessage should include("supported: json, cbor")
     }
 
     "support loading DefaultScalaModule" in {

--- a/pekko-http-jackson3/src/test/scala/com/github/pjfanning/pekkohttpjackson3/OptionalCborDependencySpec.scala
+++ b/pekko-http-jackson3/src/test/scala/com/github/pjfanning/pekkohttpjackson3/OptionalCborDependencySpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkohttpjackson3
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
+import java.net.{ URL, URLClassLoader }
+import java.util.Collections
+import scala.annotation.tailrec
+
+/**
+  * `jackson-dataformat-cbor` is an optional dependency, so JSON has to keep working when it is
+  * absent. Everything that touches it is confined to `CborConfigSupport`, which is only loaded once
+  * [[JacksonDataFormat.Cbor]] is used - this reloads the module in a class loader that cannot see
+  * the CBOR classes to prove it.
+  */
+final class OptionalCborDependencySpec extends AnyWordSpec with Matchers {
+
+  private val cborFreeLoader = new URLClassLoader(classPath, ClassLoader.getPlatformClassLoader) {
+    override def loadClass(name: String, resolve: Boolean): Class[_] = {
+      if (name.startsWith("tools.jackson.dataformat.cbor")) throw new ClassNotFoundException(name)
+      super.loadClass(name, resolve)
+    }
+  }
+
+  "pekko-http-jackson3" should {
+    "marshal JSON without jackson-dataformat-cbor on the classpath" in {
+      val mapper = objectMapperIn(cborFreeLoader, "JacksonSupport$")
+      // a JDK type rather than a Scala one: the isolated loader has its own copy of the Scala
+      // library, so a Map from this one would not be the Map its DefaultScalaModule knows
+      mapper.getClass
+        .getMethod("writeValueAsString", classOf[Any])
+        .invoke(mapper, Collections.singletonMap("bar", "bar")) shouldEqual """{"bar":"bar"}"""
+    }
+
+    "fail only once CBOR is actually asked for" in {
+      // guards the test above: without this the class loader filter could silently be a no-op
+      a[ClassNotFoundException] should be thrownBy cborFreeLoader.loadClass(
+        "tools.jackson.dataformat.cbor.CBORMapper"
+      )
+      val thrown = the[Exception] thrownBy objectMapperIn(cborFreeLoader, "CborSupport$")
+      thrown.getCause shouldBe a[NoClassDefFoundError]
+    }
+  }
+
+  private def objectMapperIn(loader: ClassLoader, supportObject: String): AnyRef = {
+    val clazz  = loader.loadClass(s"com.github.pjfanning.pekkohttpjackson3.$supportObject")
+    val module = clazz.getField("MODULE$").get(null)
+    clazz.getMethod("defaultObjectMapper").invoke(module)
+  }
+
+  private def classPath: Array[URL] = {
+    @tailrec
+    def urlsOf(loader: ClassLoader, acc: List[URL]): List[URL] =
+      loader match {
+        case null                => acc
+        case url: URLClassLoader => urlsOf(url.getParent, acc ::: url.getURLs.toList)
+        case other               => urlsOf(other.getParent, acc)
+      }
+
+    val fromLoaders = urlsOf(getClass.getClassLoader, Nil)
+    val urls        =
+      if (fromLoaders.nonEmpty) fromLoaders
+      else
+        System
+          .getProperty("java.class.path")
+          .split(File.pathSeparatorChar)
+          .map(new File(_).toURI.toURL)
+          .toList
+    urls.toArray
+  }
+}

--- a/project/Library.scala
+++ b/project/Library.scala
@@ -31,6 +31,7 @@ object Library {
   val jacksonModuleScala2  = "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % Version.jackson2
   val jacksonModuleParamNames2 = "com.fasterxml.jackson.module"       % "jackson-module-parameter-names" % Version.jackson2
   val jacksonModuleScala3  = "tools.jackson.module"                  %% "jackson-module-scala"  % Version.jackson3
+  val jacksonDataformatCbor3 = "tools.jackson.dataformat"             % "jackson-dataformat-cbor" % Version.jackson3
   val json4sCore           = "io.github.json4s"                      %% "json4s-core"           % Version.json4s
   val json4sJackson        = "io.github.json4s"                      %% "json4s-jackson"        % Version.json4s
   val json4sNative         = "io.github.json4s"                      %% "json4s-native"         % Version.json4s


### PR DESCRIPTION
`JacksonSupport` can now marshal and unmarshal `application/cbor` as well as `application/json`, through Jackson's `CBORMapper`.

## Choosing the format

By config:

```hocon
pekko-http-json.jackson.format = "cbor"   # "json" (the default) or "cbor"
```

or in code — `JacksonSupport.dataFormat` is overridable, and there are two ready made objects that pin one format whatever the config says:

```scala
import com.github.pjfanning.pekkohttpjackson3.CborSupport._   // or JsonSupport._
```

The existing `read`/`write` constraints, `jackson-modules` and buffer recycler settings apply to both formats.

## Optional dependency

`tools.jackson.dataformat:jackson-dataformat-cbor` is declared `% Optional`, so it is on the compile classpath here and marked `<optional>true</optional>` in the published POM — JSON users do not pull it in. Every reference to it is confined to `CborConfigSupport`, which is not loaded until the CBOR format is actually used. `OptionalCborDependencySpec` reloads the module in a class loader that cannot see `tools.jackson.dataformat.cbor.*` and checks that JSON marshalling still works, and that only `CborSupport` fails there.

## Binary compatibility

Two filters are added against 3.1.0, both explained in `build.sbt`:

- `mediaTypes` widens from `Seq[MediaType.WithFixedCharset]` to `Seq[MediaType]` so that it can hold the binary `application/cbor`. The erasure is unchanged and every override that compiled against the old type still conforms.
- `defaultObjectMapper` is now a real member of the `JacksonSupport` trait, so that the mapper follows `dataFormat`. In 3.1.0 the trait's interface carried a no-arg static of that name as an artifact of its `import JacksonSupport._`, uncallable from Scala.

The shared factory/mapper configuration moved to a new package private `JacksonConfigSupport`; `JacksonSupport.jacksonConfig`, `createJsonFactory` and `createObjectMapper` keep their signatures and delegate.

## Known limitation

The `Source` based streaming marshallers frame their output as a JSON array, so they stay JSON only. Under CBOR they now throw `UnsupportedOperationException` rather than emitting JSON framed CBOR.

## Testing

`+test` and `mimaReportBinaryIssues` pass for `pekko-http-jackson3` on 2.12.21, 2.13.18 and 3.3.8; the whole build's tests pass on 2.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)